### PR TITLE
STAND-65: For windows I set the default OS Name to Windows 7

### DIFF
--- a/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
+++ b/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
@@ -36,6 +36,8 @@ public class OpenmrsUtil {
 	
 	private static final String OPERATING_SYSTEM_OSX = "Mac OS X";
 	
+	private static final String OPERATING_SYSTEM_WINDOWS_DEFAULT = "Windows 7";
+	
 	private static String runtimePropertiesPathName;
 	
 	/**
@@ -65,6 +67,12 @@ public class OpenmrsUtil {
 	 * @since 1.8
 	 */
 	public static Properties getRuntimeProperties(String applicationName) {
+		
+		if(!UNIX_BASED_OPERATING_SYSTEM){
+			System.setProperty(OPERATING_SYSTEM_KEY,OPERATING_SYSTEM_WINDOWS_DEFAULT);
+		}
+		
+		//System.out.println(System.getProperty(OPERATING_SYSTEM_KEY));
 		if (applicationName == null)
 			applicationName = "openmrs";
 		


### PR DESCRIPTION
Actually this is a bug in mysql mxj connector. There are two way that can be solve there - 
(first unzip the mysql-connector-mxj-db-files-fixed.jar, make below modification and zip it again)
1.  in "platform-map.properties" file, in last line "Windows_8-x86=Win-x86 ", delete the space  after x86
2. Alternative is make a copy of folder "5-5-9\Win-x86" and rename it to "5-5-9\Windows8-amd64" or it depends on which os it is giving error, and modify "platform-map.properties" accordingly

But we cant depend on them for correcting there bug so I just set the System Property to windows 7 (System.setproperty("os.name","Windows 7")), Which will work fine for every Windows Os either 32 or 64 bit.
