### PR TITLE
STAND-65: I add another function for resetting default system property

### DIFF
--- a/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
+++ b/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
@@ -36,6 +36,8 @@ public class OpenmrsUtil {
 	
 	private static final String OPERATING_SYSTEM_OSX = "Mac OS X";
 	
+	private static final String OPERATING_SYSTEM_WINDOWS_DUMMY = "Windows 7";
+	
 	private static String runtimePropertiesPathName;
 	
 	/**
@@ -64,7 +66,10 @@ public class OpenmrsUtil {
 	 * @return runtime properties, or null if none can be found
 	 * @since 1.8
 	 */
+
 	public static Properties getRuntimeProperties(String applicationName) {
+		
+		setDummyOS();
 		if (applicationName == null)
 			applicationName = "openmrs";
 		
@@ -111,6 +116,7 @@ public class OpenmrsUtil {
 				loadProperties(props, propertyStream);
 				propertyStream.close();
 				System.out.println("Using runtime properties file: " + runtimePropertiesPathName);
+				setDefaultOS();
 				return props;
 			}
 		}
@@ -120,6 +126,7 @@ public class OpenmrsUtil {
 		
 		System.out.println("Failed to get runtime properties file.");
 		
+		setDefaultOS();
 		return null;
 		
 		/*if (applicationName == null)
@@ -254,4 +261,14 @@ public class OpenmrsUtil {
 	public static String getMysqlPort(){
 		return "3316";
 	}
+	public static void setDummyOS(){
+		if(!UNIX_BASED_OPERATING_SYSTEM){
+			System.setProperty(OPERATING_SYSTEM_KEY,OPERATING_SYSTEM_WINDOWS_DUMMY);
+		}
+	}
+	
+	public static void setDefaultOS(){
+		System.setProperty(OPERATING_SYSTEM_KEY,OPERATING_SYSTEM);
+	}
+	
 }

--- a/src/main/java/org/openmrs/standalone/StandaloneUtil.java
+++ b/src/main/java/org/openmrs/standalone/StandaloneUtil.java
@@ -421,6 +421,7 @@ public class StandaloneUtil {
 		System.out.println("Opening MySQL connection to create openmrs/test users");
     	Connection conn = DriverManager.getConnection(url, "openmrs", "test");
     	conn.close();
+    	OpenmrsUtil.setDefaultOS();
     	System.out.println("closed MySQL connection");
     	stopMySqlServer();
     }


### PR DESCRIPTION
I add another function for resetting default system properties. So it will temporarily change "os.name" for running mxj connector properly.
