### PR TITLE
STAND-100:Upgrade tomcat version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tomcat.version>7.0.96</tomcat.version>
+		<tomcat.version>7.0.99</tomcat.version>
 		<ciel.dictionary.openmrs.version>1.9.9</ciel.dictionary.openmrs.version>
 		<ciel.dictionary.version>20171118</ciel.dictionary.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tomcat.version>7.0.50</tomcat.version>
+		<tomcat.version>7.0.96</tomcat.version>
 		<ciel.dictionary.openmrs.version>1.9.9</ciel.dictionary.openmrs.version>
 		<ciel.dictionary.version>20171118</ciel.dictionary.version>
 	</properties>


### PR DESCRIPTION
The Standard alone is currently using Tomcat version that will fail to handle JARS built with compatibility with Java 9+. This PR upgrades Tomcat to version 7.0.96  that supports these JARS.


The issue worked on is on this link:
https://issues.openmrs.org/browse/STAND-100