### PR TITLE
STAND-86:Consistently use CIEL (not MVP) in the UI and under the hood

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 				<liquibasePluginArtifactId>liquibase-maven-plugin</liquibasePluginArtifactId>
 				<liquibasePluginVersion>2.0.1</liquibasePluginVersion>
 				<liquibaseDemoDataFileName>liquibase-demo-data.xml</liquibaseDemoDataFileName>
-				<liquibaseMVPDataFileName>liquibase-mvp-data.xml</liquibaseMVPDataFileName>
+				<liquibasecielDataFileName>liquibase-ciel-data.xml</liquibasecielDataFileName>
 				<liquibaseDemoDataFollowupFileName>liquibase-empty-changelog.xml</liquibaseDemoDataFollowupFileName>
 				<liquibaseEmptyDbFollowupFileName>liquibase-empty-changelog.xml</liquibaseEmptyDbFollowupFileName>
 			</properties>
@@ -97,7 +97,7 @@
 				<liquibasePluginArtifactId>liquibase-plugin</liquibasePluginArtifactId>
 				<liquibasePluginVersion>1.9.5.0</liquibasePluginVersion>
 				<liquibaseDemoDataFileName>liquibase-demo-data-18x.xml</liquibaseDemoDataFileName>
-				<liquibaseMVPDataFileName>liquibase-mvp-data-18x.xml</liquibaseMVPDataFileName>
+				<liquibasecielDataFileName>liquibase-ciel-data-18x.xml</liquibasecielDataFileName>
 				<liquibaseDemoDataFollowupFileName>liquibase-rename-helper-tables-18x.xml</liquibaseDemoDataFollowupFileName>
 				<liquibaseEmptyDbFollowupFileName>liquibase-rename-helper-tables-18x.xml</liquibaseEmptyDbFollowupFileName>
 			</properties>
@@ -223,11 +223,11 @@
 						</goals>
 					</execution>
 					<execution>
-						<id>empty-db-add-mvp-data</id>
+						<id>empty-db-add-ciel-data</id>
 						<phase>generate-resources</phase>
 						<configuration>
 							<driver>com.mysql.jdbc.Driver</driver>
-							<changeLogFile>${project.build.directory}/liquibase/${liquibaseMVPDataFileName}</changeLogFile>
+							<changeLogFile>${project.build.directory}/liquibase/${liquibasecielDataFileName}</changeLogFile>
 							<url><![CDATA[jdbc:mysql:mxj://127.0.0.1:33326/openmrs?autoReconnect=true&sessionVariables=storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&server.initialize-user=true&createDatabaseIfNotExist=true&server.basedir=${project.build.directory}/emptydatabase&server.datadir=${project.build.directory}/emptydatabase/data&server.collation-server=utf8_general_ci&server.character-set-server=utf8&server.max_allowed_packet=32M]]></url>
 							<username>openmrs</username>
 							<password>test</password>
@@ -468,7 +468,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>zip-mvp-data</id>
+						<id>zip-ciel-data</id>
 						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
@@ -477,7 +477,7 @@
 							<finalName>emptydatabase</finalName>
 							<appendAssemblyId>false</appendAssemblyId>
 							<descriptors>
-								<descriptor>src/main/assembly/zip-mvp-data.xml</descriptor>
+								<descriptor>src/main/assembly/zip-ciel-data.xml</descriptor>
 							</descriptors>
 						</configuration>
 					</execution>

--- a/src/main/assembly/zip-ciel-data.xml
+++ b/src/main/assembly/zip-ciel-data.xml
@@ -2,7 +2,7 @@
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-	<id>zip-mvp-data</id>
+	<id>zip-CIEL-data</id>
 	<baseDirectory>data</baseDirectory>
 	<formats>
 		<format>zip</format>

--- a/src/main/java/org/openmrs/standalone/MainFrame.java
+++ b/src/main/java/org/openmrs/standalone/MainFrame.java
@@ -558,7 +558,7 @@ public class MainFrame extends javax.swing.JFrame implements ActionListener, Use
 		colorHelper(demoDatabase, new Color(136, 235, 148));
 		
 		final JButton emptyDatabase = new JButton(
-		        "<html><h3>Starter Implementation</h3>Configures OpenMRS with the MVP/CIEL dictionary, but without any patient data. If you are familiar with OpenMRS and want to start a new system, this is a good place to start.</html>",
+		        "<html><h3>Starter Implementation</h3>Configures OpenMRS with the CIEL dictionary, but without any patient data. If you are familiar with OpenMRS and want to start a new system, this is a good place to start.</html>",
 		        new ImageIcon(getClass().getResource("starter_impl.png")));
 		colorHelper(emptyDatabase, new Color(255, 243, 136));
 		

--- a/src/main/liquibase/liquibase-ciel-data-18x.xml
+++ b/src/main/liquibase/liquibase-ciel-data-18x.xml
@@ -22,7 +22,7 @@
 	
 	<changeSet id="20120315-1100" author="standalone" dbms="mysql">
 		<comment>Adding mvp data</comment>
-		<sqlFile path="openmrs_concepts_${ciel.dictionary.openmrs.version}_${ciel.dictionary.version}.sql" encoding="UTF-8" />
+		<sqlFile path="openmrs_concepts_${ciel.dictionary.openmrs.version}_${ciel.dictionary.version}.sql" encoding="UTF-8" >
 		
 		<!-- avoid the Unknown column 'voided' in 'where clause' for Migration failed for change set liquibase-update-to-latest.xml::20090316-1008::vanand -->
 		<addColumn tableName="concept_source">

--- a/src/main/liquibase/liquibase-ciel-data.xml
+++ b/src/main/liquibase/liquibase-ciel-data.xml
@@ -5,7 +5,8 @@
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
 	<changeSet id="20120315-1000" author="standalone" dbms="mysql">
-		<comment>Preparing schema for adding mvp data</comment>
+		<validChecksum>3:dc136a76a36273b5cdb2f47b0eb24522</validChecksum>
+		<comment>Preparing schema for adding ciel data</comment>
 
 		<sql>SET FOREIGN_KEY_CHECKS=0</sql>
 		<dropTable tableName="concept" />
@@ -19,19 +20,17 @@
 		<dropTable tableName="concept_name_tag" />
 		<dropTable tableName="concept_name_tag_map" />
 		<dropTable tableName="concept_numeric" />
-		<!-- <dropTable tableName="concept_proposal" /> not contained in the mvp 
-			dict -->
+		<!-- <dropTable tableName="concept_proposal" /> not contained in the ciel			dict -->
 		<!-- <dropTable tableName="concept_proposal_tag_map" /> not contained in 
-			the mvp dict -->
+			the ciel dict -->
 		<dropTable tableName="concept_reference_map" />
 		<dropTable tableName="concept_reference_source" />
 		<dropTable tableName="concept_reference_term" />
 		<dropTable tableName="concept_reference_term_map" />
 		<dropTable tableName="concept_set" />
 		<dropTable tableName="concept_set_derived" />
-		<dropTable tableName="concept_state_conversion" />
-		<!-- <dropTable tableName="concept_stop_word" /> not contained in the mvp 
-			dict -->
+		<dropTable tableName="concept_state_conversion" ></dropTable>
+		<!-- <dropTable tableName="concept_stop_word" /> not contained in the ciel			dict -->
 
 		<delete tableName="liquibasechangelog">
 			<where>id="20110919-0638" or id="20110301-1030c-fix"</where>
@@ -49,7 +48,8 @@
 	</changeSet>
 
 	<changeSet id="20120315-1100" author="standalone" dbms="mysql">
-		<comment>Adding mvp data</comment>
+		<validChecksum>3:da27117b32a07c5b89b9df072d8d3b45</validChecksum>
+		<comment>Adding ciel data</comment>
 		<sqlFile path="openmrs_concepts_${ciel.dictionary.openmrs.version}_${ciel.dictionary.version}.sql" encoding="UTF-8" />
 
 		<!-- We need to make the liquibasechangelog table modifications to 2.0.x 


### PR DESCRIPTION
This is what I did:
1. I renamed the MVP/MVP CIEL data file to  CIEL data file in the script. 
2. I changed MVP CIEL dictionary to CIEL dictionary so that in the process of building the standalone should not use a file called "mvp-data.sql" but rather "CIEL-dictionary.sql" and any text in the UI of the standalone (e.g. the "Starter Implementation" option) should only say CIEL, not MVP/CIEL or MVP.

Issue worked on:
https://issues.openmrs.org/browse/STAND-86

