### PR TITLE
TRUNK-4830-AC upgrade Liquibase maven plugin to 3.10.2 and refactor l…

### DIFF
--- a/openmrs_concepts_1.9.9_20171118_schema_only.sql
+++ b/openmrs_concepts_1.9.9_20171118_schema_only.sql
@@ -1,0 +1,596 @@
+/*
+ Navicat Premium Data Transfer
+
+ Source Server         : OpenMRS1.9
+ Source Server Type    : MySQL
+ Source Server Version : 50509
+ Source Host           : localhost
+ Source Database       : liquibaserunner
+
+ Target Server Type    : MySQL
+ Target Server Version : 50509
+ File Encoding         : utf-8
+
+ Date: 11/19/2017 10:28:49 AM
+
+ This file is a subset of openmrs_concepts_1.9.9_20171118.sql. It contains the DDL parts only and all insert statements
+ were removed. Using this file when testing the build is much faster than testing with the full CIEL data set.
+
+ To use this file in a build change src/main/liquibase/liquibase-ciel-data.xml as follows:
+
+ Replace
+
+   <sqlFile path="openmrs_concepts_${ciel.dictionary.openmrs.version}_${ciel.dictionary.version}.sql" encoding="UTF-8" />
+
+ with
+
+   <sqlFile path="openmrs_concepts_1.9.9_20171118_schema_only.sql" encoding="UTF-8" />
+
+ Do *not* forget to revert the change after testing the build is finished.
+
+*/
+
+SET NAMES utf8;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ----------------------------
+--  Table structure for `concept`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept`;
+CREATE TABLE `concept` (
+  `concept_id` int(11) NOT NULL AUTO_INCREMENT,
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `short_name` varchar(255) DEFAULT NULL,
+  `description` text,
+  `form_text` text,
+  `datatype_id` int(11) NOT NULL DEFAULT '0',
+  `class_id` int(11) NOT NULL DEFAULT '0',
+  `is_set` tinyint(1) NOT NULL DEFAULT '0',
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `version` varchar(50) DEFAULT NULL,
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_id`),
+  UNIQUE KEY `concept_uuid_index` (`uuid`),
+  KEY `concept_classes` (`class_id`),
+  KEY `concept_creator` (`creator`),
+  KEY `concept_datatypes` (`datatype_id`),
+  KEY `user_who_changed_concept` (`changed_by`),
+  KEY `concept_code` (`version`),
+  KEY `concept_ndx` (`version`),
+  KEY `user_who_retired_concept` (`retired_by`),
+  CONSTRAINT `concept_classes` FOREIGN KEY (`class_id`) REFERENCES `concept_class` (`concept_class_id`),
+  CONSTRAINT `concept_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `concept_datatypes` FOREIGN KEY (`datatype_id`) REFERENCES `concept_datatype` (`concept_datatype_id`),
+  CONSTRAINT `user_who_changed_concept` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_retired_concept` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=165084 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_answer`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_answer`;
+CREATE TABLE `concept_answer` (
+  `concept_answer_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `answer_concept` int(11) DEFAULT NULL,
+  `answer_drug` int(11) DEFAULT NULL,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `uuid` char(38) NOT NULL,
+  `sort_weight` double DEFAULT NULL,
+  PRIMARY KEY (`concept_answer_id`),
+  UNIQUE KEY `concept_answer_uuid_index` (`uuid`),
+  KEY `answer_creator` (`creator`),
+  KEY `answer` (`answer_concept`),
+  KEY `answers_for_concept` (`concept_id`),
+  KEY `answer_answer_drug_fk` (`answer_drug`),
+  CONSTRAINT `answer_answer_drug_fk` FOREIGN KEY (`answer_drug`) REFERENCES `drug` (`drug_id`),
+  CONSTRAINT `answer` FOREIGN KEY (`answer_concept`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `answers_for_concept` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `answer_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=6816 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_class`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_class`;
+CREATE TABLE `concept_class` (
+  `concept_class_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `description` varchar(255) NOT NULL DEFAULT '',
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_class_id`),
+  UNIQUE KEY `concept_class_uuid_index` (`uuid`),
+  KEY `concept_class_creator` (`creator`),
+  KEY `user_who_retired_concept_class` (`retired_by`),
+  KEY `concept_class_retired_status` (`retired`),
+  CONSTRAINT `concept_class_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_retired_concept_class` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_complex`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_complex`;
+CREATE TABLE `concept_complex` (
+  `concept_id` int(11) NOT NULL,
+  `handler` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`concept_id`),
+  CONSTRAINT `concept_attributes` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_datatype`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_datatype`;
+
+CREATE TABLE `concept_datatype` (
+  `concept_datatype_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `hl7_abbreviation` varchar(3) DEFAULT NULL,
+  `description` varchar(255) NOT NULL DEFAULT '',
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_datatype_id`),
+  UNIQUE KEY `concept_datatype_uuid_index` (`uuid`),
+  KEY `concept_datatype_creator` (`creator`),
+  KEY `user_who_retired_concept_datatype` (`retired_by`),
+  KEY `concept_datatype_retired_status` (`retired`),
+  CONSTRAINT `concept_datatype_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_retired_concept_datatype` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_description`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_description`;
+CREATE TABLE `concept_description` (
+  `concept_description_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `description` text NOT NULL,
+  `locale` varchar(50) NOT NULL DEFAULT '',
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_description_id`),
+  UNIQUE KEY `concept_description_uuid_index` (`uuid`),
+  KEY `concept_being_described` (`concept_id`),
+  KEY `user_who_created_description` (`creator`),
+  KEY `user_who_changed_description` (`changed_by`),
+  CONSTRAINT `description_for_concept` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `user_who_changed_description` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_created_description` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=18340 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_map_type`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_map_type`;
+CREATE TABLE `concept_map_type` (
+  `concept_map_type_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_bin NOT NULL,
+  `description` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `creator` int(11) NOT NULL,
+  `date_created` datetime NOT NULL,
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `is_hidden` tinyint(1) DEFAULT NULL,
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `uuid` char(38) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`concept_map_type_id`),
+  UNIQUE KEY `uuid` (`uuid`),
+  UNIQUE KEY `name` (`name`),
+  KEY `mapped_user_creator_concept_map_type` (`creator`),
+  KEY `mapped_user_changed_concept_map_type` (`changed_by`),
+  KEY `mapped_user_retired_concept_map_type` (`retired_by`),
+  CONSTRAINT `mapped_user_changed_concept_map_type` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `mapped_user_creator_concept_map_type` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `mapped_user_retired_concept_map_type` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=71 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_name`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_name`;
+CREATE TABLE `concept_name` (
+  `concept_id` int(11) DEFAULT NULL,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `locale` varchar(50) NOT NULL DEFAULT '',
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `concept_name_id` int(11) NOT NULL AUTO_INCREMENT,
+  `voided` tinyint(1) NOT NULL DEFAULT '0',
+  `voided_by` int(11) DEFAULT NULL,
+  `date_voided` datetime DEFAULT NULL,
+  `void_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  `concept_name_type` varchar(50) DEFAULT NULL,
+  `locale_preferred` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`concept_name_id`),
+  UNIQUE KEY `concept_name_id` (`concept_name_id`),
+  UNIQUE KEY `concept_name_uuid_index` (`uuid`),
+  KEY `user_who_created_name` (`creator`),
+  KEY `name_of_concept` (`name`),
+  KEY `concept_id` (`concept_id`),
+  KEY `unique_concept_name_id` (`concept_id`),
+  KEY `user_who_voided_name` (`voided_by`),
+  CONSTRAINT `name_for_concept` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `user_who_created_name` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_voided_this_name` FOREIGN KEY (`voided_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=141475 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_name_tag`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_name_tag`;
+CREATE TABLE `concept_name_tag` (
+  `concept_name_tag_id` int(11) NOT NULL AUTO_INCREMENT,
+  `tag` varchar(50) NOT NULL,
+  `description` text NOT NULL,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `voided` tinyint(1) NOT NULL DEFAULT '0',
+  `voided_by` int(11) DEFAULT NULL,
+  `date_voided` datetime DEFAULT NULL,
+  `void_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_name_tag_id`),
+  UNIQUE KEY `concept_name_tag_id` (`concept_name_tag_id`),
+  UNIQUE KEY `concept_name_tag_id_2` (`concept_name_tag_id`),
+  UNIQUE KEY `concept_name_tag_unique_tags` (`tag`),
+  UNIQUE KEY `concept_name_tag_uuid_index` (`uuid`),
+  KEY `user_who_created_name_tag` (`creator`),
+  KEY `user_who_voided_name_tag` (`voided_by`)
+) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_name_tag_map`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_name_tag_map`;
+CREATE TABLE `concept_name_tag_map` (
+  `concept_name_id` int(11) NOT NULL,
+  `concept_name_tag_id` int(11) NOT NULL,
+  KEY `map_name` (`concept_name_id`),
+  KEY `map_name_tag` (`concept_name_tag_id`),
+  CONSTRAINT `mapped_concept_name_tag` FOREIGN KEY (`concept_name_tag_id`) REFERENCES `concept_name_tag` (`concept_name_tag_id`),
+  CONSTRAINT `mapped_concept_name` FOREIGN KEY (`concept_name_id`) REFERENCES `concept_name` (`concept_name_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_numeric`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_numeric`;
+CREATE TABLE `concept_numeric` (
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `hi_absolute` double DEFAULT NULL,
+  `hi_critical` double DEFAULT NULL,
+  `hi_normal` double DEFAULT NULL,
+  `low_absolute` double DEFAULT NULL,
+  `low_critical` double DEFAULT NULL,
+  `low_normal` double DEFAULT NULL,
+  `units` varchar(50) DEFAULT NULL,
+  `precise` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`concept_id`),
+  CONSTRAINT `numeric_attributes` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_proposal`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_proposal`;
+CREATE TABLE `concept_proposal` (
+  `concept_proposal_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) DEFAULT NULL,
+  `encounter_id` int(11) DEFAULT NULL,
+  `original_text` varchar(255) NOT NULL DEFAULT '',
+  `final_text` varchar(255) DEFAULT NULL,
+  `obs_id` int(11) DEFAULT NULL,
+  `obs_concept_id` int(11) DEFAULT NULL,
+  `state` varchar(32) NOT NULL DEFAULT 'UNMAPPED',
+  `comments` varchar(255) DEFAULT NULL,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0002-11-30 00:00:00',
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `locale` varchar(50) NOT NULL DEFAULT '',
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_proposal_id`),
+  UNIQUE KEY `concept_proposal_uuid_index` (`uuid`),
+  KEY `user_who_changed_proposal` (`changed_by`),
+  KEY `concept_for_proposal` (`concept_id`),
+  KEY `user_who_created_proposal` (`creator`),
+  KEY `encounter_for_proposal` (`encounter_id`),
+  KEY `proposal_obs_concept_id` (`obs_concept_id`),
+  KEY `proposal_obs_id` (`obs_id`),
+  CONSTRAINT `concept_for_proposal` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `encounter_for_proposal` FOREIGN KEY (`encounter_id`) REFERENCES `encounter` (`encounter_id`),
+  CONSTRAINT `proposal_obs_concept_id` FOREIGN KEY (`obs_concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `proposal_obs_id` FOREIGN KEY (`obs_id`) REFERENCES `obs` (`obs_id`),
+  CONSTRAINT `user_who_changed_proposal` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_created_proposal` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_proposal_tag_map`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_proposal_tag_map`;
+CREATE TABLE `concept_proposal_tag_map` (
+  `concept_proposal_id` int(11) NOT NULL,
+  `concept_name_tag_id` int(11) NOT NULL,
+  KEY `mapped_concept_proposal_tag` (`concept_name_tag_id`),
+  KEY `mapped_concept_proposal` (`concept_proposal_id`),
+  CONSTRAINT `mapped_concept_proposal` FOREIGN KEY (`concept_proposal_id`) REFERENCES `concept_proposal` (`concept_proposal_id`),
+  CONSTRAINT `mapped_concept_proposal_tag` FOREIGN KEY (`concept_name_tag_id`) REFERENCES `concept_name_tag` (`concept_name_tag_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_reference_map`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_reference_map`;
+CREATE TABLE `concept_reference_map` (
+  `concept_map_id` int(11) NOT NULL AUTO_INCREMENT,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `uuid` char(38) NOT NULL,
+  `concept_reference_term_id` int(11) NOT NULL,
+  `concept_map_type_id` int(11) NOT NULL DEFAULT '1',
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  PRIMARY KEY (`concept_map_id`),
+  UNIQUE KEY `concept_map_uuid_index` (`uuid`),
+  KEY `map_creator` (`creator`),
+  KEY `map_for_concept` (`concept_id`),
+  KEY `mapped_concept_map_type` (`concept_map_type_id`),
+  KEY `mapped_user_changed_ref_term` (`changed_by`),
+  KEY `mapped_concept_reference_term` (`concept_reference_term_id`),
+  CONSTRAINT `mapped_concept_map_type` FOREIGN KEY (`concept_map_type_id`) REFERENCES `concept_map_type` (`concept_map_type_id`),
+  CONSTRAINT `mapped_concept_reference_term` FOREIGN KEY (`concept_reference_term_id`) REFERENCES `concept_reference_term` (`concept_reference_term_id`),
+  CONSTRAINT `mapped_user_changed_ref_term` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `map_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `map_for_concept` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=283288 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_reference_source`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_reference_source`;
+CREATE TABLE `concept_reference_source` (
+  `concept_source_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) NOT NULL DEFAULT '',
+  `description` text NOT NULL,
+  `hl7_code` varchar(50) DEFAULT NULL,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) DEFAULT NULL,
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_source_id`),
+  UNIQUE KEY `concept_source_uuid_index` (`uuid`),
+  UNIQUE KEY `concept_source_unique_hl7_codes` (`hl7_code`),
+  KEY `concept_source_creator` (`creator`),
+  KEY `user_who_voided_concept_source` (`retired_by`),
+  KEY `unique_hl7_code` (`hl7_code`,`retired`),
+  CONSTRAINT `concept_source_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `user_who_retired_concept_source` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_reference_term`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_reference_term`;
+CREATE TABLE `concept_reference_term` (
+  `concept_reference_term_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_source_id` int(11) NOT NULL,
+  `name` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `code` varchar(255) COLLATE utf8_bin NOT NULL,
+  `version` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `creator` int(11) NOT NULL,
+  `date_created` datetime NOT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `changed_by` int(11) DEFAULT NULL,
+  `retired` tinyint(1) NOT NULL DEFAULT '0',
+  `retired_by` int(11) DEFAULT NULL,
+  `date_retired` datetime DEFAULT NULL,
+  `retire_reason` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `uuid` char(38) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`concept_reference_term_id`),
+  UNIQUE KEY `uuid` (`uuid`),
+  KEY `mapped_user_creator` (`creator`),
+  KEY `mapped_user_changed` (`changed_by`),
+  KEY `mapped_user_retired` (`retired_by`),
+  KEY `mapped_concept_source` (`concept_source_id`),
+  KEY `idx_code_concept_reference_term` (`code`),
+  CONSTRAINT `mapped_concept_source` FOREIGN KEY (`concept_source_id`) REFERENCES `concept_reference_source` (`concept_source_id`),
+  CONSTRAINT `mapped_user_changed` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `mapped_user_creator` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `mapped_user_retired` FOREIGN KEY (`retired_by`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=283288 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_reference_term_map`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_reference_term_map`;
+CREATE TABLE `concept_reference_term_map` (
+  `concept_reference_term_map_id` int(11) NOT NULL AUTO_INCREMENT,
+  `term_a_id` int(11) NOT NULL,
+  `term_b_id` int(11) NOT NULL,
+  `a_is_to_b_id` int(11) NOT NULL,
+  `creator` int(11) NOT NULL,
+  `date_created` datetime NOT NULL,
+  `changed_by` int(11) DEFAULT NULL,
+  `date_changed` datetime DEFAULT NULL,
+  `uuid` char(38) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`concept_reference_term_map_id`),
+  UNIQUE KEY `uuid` (`uuid`),
+  KEY `mapped_term_a` (`term_a_id`),
+  KEY `mapped_term_b` (`term_b_id`),
+  KEY `mapped_concept_map_type_ref_term_map` (`a_is_to_b_id`),
+  KEY `mapped_user_creator_ref_term_map` (`creator`),
+  KEY `mapped_user_changed_ref_term_map` (`changed_by`),
+  CONSTRAINT `mapped_user_changed_ref_term_map` FOREIGN KEY (`changed_by`) REFERENCES `users` (`user_id`),
+  CONSTRAINT `mapped_concept_map_type_ref_term_map` FOREIGN KEY (`a_is_to_b_id`) REFERENCES `concept_map_type` (`concept_map_type_id`),
+  CONSTRAINT `mapped_term_a` FOREIGN KEY (`term_a_id`) REFERENCES `concept_reference_term` (`concept_reference_term_id`),
+  CONSTRAINT `mapped_term_b` FOREIGN KEY (`term_b_id`) REFERENCES `concept_reference_term` (`concept_reference_term_id`),
+  CONSTRAINT `mapped_user_creator_ref_term_map` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_set`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_set`;
+CREATE TABLE `concept_set` (
+  `concept_set_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `concept_set` int(11) NOT NULL DEFAULT '0',
+  `sort_weight` double DEFAULT NULL,
+  `creator` int(11) NOT NULL DEFAULT '0',
+  `date_created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_set_id`),
+  UNIQUE KEY `concept_set_uuid_index` (`uuid`),
+  KEY `has_a` (`concept_set`),
+  KEY `user_who_created` (`creator`),
+  KEY `idx_concept_set_concept` (`concept_id`),
+  CONSTRAINT `has_a` FOREIGN KEY (`concept_set`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `is_a` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `user_who_created` FOREIGN KEY (`creator`) REFERENCES `users` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2538 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_set_derived`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_set_derived`;
+CREATE TABLE `concept_set_derived` (
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `concept_set` int(11) NOT NULL DEFAULT '0',
+  `sort_weight` double DEFAULT NULL,
+  `uuid` char(38) DEFAULT NULL,
+  PRIMARY KEY (`concept_id`,`concept_set`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_state_conversion`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_state_conversion`;
+CREATE TABLE `concept_state_conversion` (
+  `concept_state_conversion_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) DEFAULT '0',
+  `program_workflow_id` int(11) DEFAULT '0',
+  `program_workflow_state_id` int(11) DEFAULT '0',
+  `uuid` char(38) NOT NULL,
+  PRIMARY KEY (`concept_state_conversion_id`),
+  UNIQUE KEY `concept_state_conversion_uuid_index` (`uuid`),
+  UNIQUE KEY `unique_workflow_concept_in_conversion` (`program_workflow_id`,`concept_id`),
+  KEY `triggering_concept` (`concept_id`),
+  KEY `affected_workflow` (`program_workflow_id`),
+  KEY `resulting_state` (`program_workflow_state_id`),
+  CONSTRAINT `concept_triggers_conversion` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `conversion_involves_workflow` FOREIGN KEY (`program_workflow_id`) REFERENCES `program_workflow` (`program_workflow_id`),
+  CONSTRAINT `conversion_to_state` FOREIGN KEY (`program_workflow_state_id`) REFERENCES `program_workflow_state` (`program_workflow_state_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_stop_word`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_stop_word`;
+CREATE TABLE `concept_stop_word` (
+  `concept_stop_word_id` int(11) NOT NULL AUTO_INCREMENT,
+  `word` varchar(50) COLLATE utf8_bin NOT NULL,
+  `locale` varchar(20) COLLATE utf8_bin NOT NULL DEFAULT 'en',
+  `uuid` char(38) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`concept_stop_word_id`),
+  UNIQUE KEY `uuid` (`uuid`),
+  UNIQUE KEY `Unique_StopWord_Key` (`word`,`locale`)
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+COMMIT;
+
+-- ----------------------------
+--  Table structure for `concept_word`
+-- ----------------------------
+DROP TABLE IF EXISTS `concept_word`;
+CREATE TABLE `concept_word` (
+  `concept_word_id` int(11) NOT NULL AUTO_INCREMENT,
+  `concept_id` int(11) NOT NULL DEFAULT '0',
+  `word` varchar(50) NOT NULL DEFAULT '',
+  `locale` varchar(20) NOT NULL DEFAULT '',
+  `concept_name_id` int(11) NOT NULL,
+  `weight` double DEFAULT '1',
+  PRIMARY KEY (`concept_word_id`,`word`,`locale`),
+  KEY `word_in_concept_name` (`word`),
+  KEY `concept_word_concept_idx` (`concept_id`),
+  KEY `word_for_name` (`concept_name_id`),
+  KEY `concept_word_weight_index` (`weight`),
+  CONSTRAINT `word_for` FOREIGN KEY (`concept_id`) REFERENCES `concept` (`concept_id`),
+  CONSTRAINT `word_for_name` FOREIGN KEY (`concept_name_id`) REFERENCES `concept_name` (`concept_name_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1277011 DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 0;

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 		<tomcat.version>7.0.100</tomcat.version>
 		<ciel.dictionary.openmrs.version>1.9.9</ciel.dictionary.openmrs.version>
 		<ciel.dictionary.version>20200822</ciel.dictionary.version>
+		<liquibase.plugin.version>3.10.2</liquibase.plugin.version>
 	</properties>
 
 	<dependencies>
@@ -79,7 +80,7 @@
 			</activation>
 			<properties>
 				<liquibasePluginArtifactId>liquibase-maven-plugin</liquibasePluginArtifactId>
-				<liquibasePluginVersion>3.10.2</liquibasePluginVersion>
+				<liquibasePluginVersion>${liquibase.plugin.version}</liquibasePluginVersion>
 				<liquibaseDemoDataFileName>liquibase-demo-data.xml</liquibaseDemoDataFileName>
 				<liquibasecielDataFileName>liquibase-ciel-data.xml</liquibasecielDataFileName>
 				<liquibaseDemoDataFollowupFileName>liquibase-empty-changelog.xml</liquibaseDemoDataFollowupFileName>
@@ -579,7 +580,7 @@
 											liquibase-maven-plugin
 										</artifactId>
 										<versionRange>
-											[2.0.1,)
+											[${liquibase.plugin.version},)
 										</versionRange>
 										<goals>
 											<goal>update</goal>

--- a/src/main/liquibase/liquibase-ciel-data.xml
+++ b/src/main/liquibase/liquibase-ciel-data.xml
@@ -1,11 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
-    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+	<!--
+		The table "concept_set_derived" was removed in openmrs-api version 2.0.
+
+		Dropping the table was extracted into a separate change set to allow for
+		adding the precondition.
+	 -->
+	<changeSet id="20201003-1000" author="standalone" dbms="mysql">
+		<preConditions onFail="MARK_RAN">
+			<tableExists tableName="concept_set_derived"/>
+		</preConditions>
+		<comment>Preparing schema for adding ciel data</comment>
+
+		<sql>SET FOREIGN_KEY_CHECKS=0</sql>
+
+		<dropTable tableName="concept_set_derived"/>
+
+		<sql>SET FOREIGN_KEY_CHECKS=1</sql>
+	</changeSet>
 
 	<changeSet id="20120315-1000" author="standalone" dbms="mysql">
 		<validCheckSum>3:dc136a76a36273b5cdb2f47b0eb24522</validCheckSum>
+		<validCheckSum>8:842f411a0f413d97a8aae085bdd90c95</validCheckSum>
 		<comment>Preparing schema for adding ciel data</comment>
 
 		<sql>SET FOREIGN_KEY_CHECKS=0</sql>
@@ -20,7 +43,7 @@
 		<dropTable tableName="concept_name_tag" />
 		<dropTable tableName="concept_name_tag_map" />
 		<dropTable tableName="concept_numeric" />
-		<!-- <dropTable tableName="concept_proposal" /> not contained in the ciel			dict -->
+		<!-- <dropTable tableName="concept_proposal" /> not contained in the ciel dict -->
 		<!-- <dropTable tableName="concept_proposal_tag_map" /> not contained in 
 			the ciel dict -->
 		<dropTable tableName="concept_reference_map" />
@@ -28,9 +51,8 @@
 		<dropTable tableName="concept_reference_term" />
 		<dropTable tableName="concept_reference_term_map" />
 		<dropTable tableName="concept_set" />
-		<dropTable tableName="concept_set_derived" />
 		<dropTable tableName="concept_state_conversion" ></dropTable>
-		<!-- <dropTable tableName="concept_stop_word" /> not contained in the ciel			dict -->
+		<!-- <dropTable tableName="concept_stop_word" /> not contained in the ciel dict -->
 
 		<delete tableName="liquibasechangelog">
 			<where>id="20110919-0638" or id="20110301-1030c-fix"</where>
@@ -40,8 +62,8 @@
 			<!-- Skip this changeset since it is unnecessary and takes too long -->
 			insert into liquibasechangelog values('200905150821', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10242,
-			'EXECUTED', '3:c0b7abc7eb00f243325b4a3fb2afc614', 'Custom SQL',
-			'Deleting duplicate concept word keys', NULL, '3.10.2', NULL, NULL, NULL)
+			'EXECUTED', '8:096845d15f847ebefb86fec52322ee8f', 'Custom SQL',
+			'Deleting duplicate concept word keys', NULL, '3.10.2', NULL, NULL, NULL);
 		</sql>
 
 		<sql>SET FOREIGN_KEY_CHECKS=1</sql>
@@ -52,10 +74,10 @@
 		<comment>Adding ciel data</comment>
 		<sqlFile path="openmrs_concepts_${ciel.dictionary.openmrs.version}_${ciel.dictionary.version}.sql" encoding="UTF-8" />
 
-		<!-- We need to make the liquibasechangelog table modifications to 2.0.x 
-			within this changeset because the one in demo data was created with version 
-			1.9.x, so that liquibase doesn't fail when entering this changeset into table 
-			because of the missing columns that are required. See http://www.liquibase.org/download 
+		<!-- We need to make the liquibasechangelog table modifications to 2.0.x
+			within this changeset because the one in demo data was created with version
+			1.9.x, so that liquibase doesn't fail when entering this changeset into table
+			because of the missing columns that are required. See http://www.liquibase.org/download
 			for more details. -->
 
 		<ext:modifyColumn tableName="liquibasechangelog">
@@ -68,53 +90,53 @@
 			<!-- Skip these changesets because the concept_word table does not exist in mvp data -->
 			insert into liquibasechangelog values('200905150814', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10069,
-			'EXECUTED', '3:44c729b393232d702553e0768cf94994', 'Delete Data',
+			'EXECUTED', '8:d4325318f852b3ede2798d3a08f42088', 'Delete Data',
 			'Deleting invalid concept words', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('200905071626', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10070,
-			'EXECUTED', '3:d29884c3ef8fd867c3c2ffbd557c14c2', 'Create Index',
+			'EXECUTED', '8:56e2d2bb15a004bd5ac5bf362e7e3f82', 'Create Index',
 			'Add an index to the concept_word.concept_id column (This update may fail if it already exists)', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('20090414-0811a', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10234,
-			'EXECUTED', '3:f027a0ad38c0f6302def391da78aaaee', 'Drop Foreign Key Constraint',
+			'EXECUTED', '8:a996aae13913281567000b04221e17b4', 'Drop Foreign Key Constraint',
 			'Dropping foreign key on concept_word.concept_id column', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('20090428-0811aa', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10235,
-			'EXECUTED', '3:58d8f3df1fe704714a7b4957a6c0e7f7', 'Drop Foreign Key Constraint',
+			'EXECUTED', '8:210185827394b8982208a79333b4c33f', 'Drop Foreign Key Constraint',
 			'Removing concept_word.concept_name_id foreign key so that primary key can be changed to concept_word_id', NULL, '3.10.2', NULL, NULL, NULL);
 
 			insert into liquibasechangelog values('20090414-0811b', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10236,
-			'EXECUTED', '3:982d502e56854922542286cead4c09ce', 'Drop Primary Key',
+			'EXECUTED', '8:68201f30b43cec5ad62a2c0ad1ef8cf3', 'Drop Primary Key',
 			'Dropping non-integer primary key on concept word table before adding new integer one', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('20090414-0812', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10237,
-			'EXECUTED', '3:948e635fe3f63122856ca9b8a174352b', 'Add Column',
+			'EXECUTED', '8:be261ff12facaf51c32cbd2c442149ce', 'Add Column',
 			'Adding integer primary key to concept word table', NULL, '3.10.2', NULL, NULL, NULL);
 
 			insert into liquibasechangelog values('20090414-0812b', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10238,
-			'EXECUTED', '3:bd7731e58f3db9b944905597a08eb6cb', 'Add Foreign Key Constraint',
+			'EXECUTED', '8:6a9f6449f288592ea5e47bae65986340', 'Add Foreign Key Constraint',
 			'Re-adding foreign key for concept_word.concept_name_id', NULL, '3.10.2', NULL, NULL, NULL);
 
 			insert into liquibasechangelog values('20090428-0854', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10239,
-			'EXECUTED', '3:11086a37155507c0238c9532f66b172b', 'Add Foreign Key Constraint',
+			'EXECUTED', '8:1ad9516c3ccff7c5d0f2c4d0ccb4d820', 'Add Foreign Key Constraint',
 			'Adding foreign key for concept_word.concept_id column', NULL, '3.10.2', NULL, NULL, NULL);
 
 			insert into liquibasechangelog values('200904271042', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10241,
-			'EXECUTED', '3:db63ce704aff4741c52181d1c825ab62', 'Drop Column',
+			'EXECUTED', '8:63e5f7ca7868c45cda0fcb1250323e00', 'Drop Column',
 			'Remove the now unused synonym column', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('20101209-1721', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10357,
 			'EXECUTED', '3:351460e0f822555b77acff1a89bec267', 'Add Column',
-			'Add weight column to concept_word table', NULL, '3.10.2', NULL, NULL, NULL);	
+			'Add weight column to concept_word table', NULL, '3.10.2', NULL, NULL, NULL);
 			
 			insert into liquibasechangelog values('20101209-1722', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10358,
@@ -129,8 +151,8 @@
 			<!-- Skip this changeset because the concept_set_derived table does not exist in mvp data -->
 			insert into liquibasechangelog values('200907161638-4', 'bwolfe',
 			'liquibase-update-to-latest.xml', '2012-03-15 11:00:00', 10248,
-			'EXECUTED', '3:3ffccaa291298fea317eb7025c058492', 'Modify Column',
-			'Change concept_set_derived.sort_weight from a double(22,0) to a double', NULL, '3.10.2', NULL, NULL, NULL);			
+			'EXECUTED', '8:e9cf31e6d6c61bd1fe037f91a615a8bc', 'Modify Column',
+			'Change concept_set_derived.sort_weight from a double(22,0) to a double', NULL, '3.10.2', NULL, NULL, NULL);
 		</sql>
 	</changeSet>
 	


### PR DESCRIPTION
…iquibase-ciel-data.xml

@dkayiwa and @gitcliff here comes the fix for building openmrs-standalone with openmrs-core version **2.4.0**.

I merged my changes with the current master branch and noticed that the OpenMRS version in `pom.xml` file is **2.3.1**.

**This is going to be an issue** as OpenMRS 2.3.x still uses Liquibase 2.0.5 while this pull request updates the Liquibase Maven Plugin to 3.10.2. **Mixing Liquibase 2.x and 3.x in the same build is not going to work as Liquibase 3.x introduced breaking changes.**

I suggest you create a 2.3.x branch for openmrs-standalone to be able to re-build releases that are based on OpenMRS 2.3.x or earlier and use the master branch as of OpenMRS 2.4.x.

Any questions please let me know.
