### PR TITLE
Updating Standalone OpenMRS version to 2.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <liquibase.demodata.followup.filename>liquibase-empty-changelog.xml</liquibase.demodata.followup.filename>
     <liquibase.emptydb.followup.filename>liquibase-empty-changelog.xml</liquibase.emptydb.followup.filename>
 
-    <openmrs.version>2.4.0-SNAPSHOT</openmrs.version>
+    <openmrs.version>2.6.0-SNAPSHOT</openmrs.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomcat.version>7.0.50</tomcat.version>
   </properties>


### PR DESCRIPTION
@dkayiwa  do you think this fixes the build failure at

https://ci.openmrs.org/download/REFAPP-OMODDISTRO-TS/build_logs/REFAPP-OMODDISTRO-TS-12028.log

And standalone is still running **tomcat 7.0.50** , don't you think we need it updated to **8 or 9** as well ?