### PR TITLE
STAND-114: Enable Support for Expert Mode in OpenMRS Standalone

### DIFF
--- a/src/main/java/org/openmrs/standalone/MariaDbController.java
+++ b/src/main/java/org/openmrs/standalone/MariaDbController.java
@@ -13,9 +13,8 @@ public class MariaDbController {
     public static final String DATABASE_NAME = "openmrs";
     private static final String MARIA_DB_BASE_DIR = "database";
     private static final String MARIA_DB_DATA_DIR = Paths.get(MARIA_DB_BASE_DIR, "data").toString();
-    private static final String DATABASE_USER_NAME = "openmrs";
-    private static final String DEFAULT_PASSWORD = "test";
-    private static final String DEFAULT_ROOT_PASSWORD = "rootpass";
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "rootpass";
 
     private static DB mariaDB;
     private static DBConfigurationBuilder mariaDBConfig;
@@ -60,11 +59,11 @@ public class MariaDbController {
         mariaDB.start();
 
         // Ensure root user exists and has correct password and privileges
-        mariaDB.run("ALTER USER 'root'@'localhost' IDENTIFIED BY '" + DEFAULT_ROOT_PASSWORD + "';");
+        mariaDB.run("ALTER USER 'root'@'localhost' IDENTIFIED BY '" + ROOT_PASSWORD + "';");
         mariaDB.run("GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;");
 
         // Create the OpenMRS database schema if it doesn't exist
-        mariaDB.createDB(DATABASE_NAME, "root", "rootpass");
+        mariaDB.createDB(DATABASE_NAME, ROOT_USER, ROOT_PASSWORD);
     }
 
     private static String safeResolveProperty(Properties properties, String key, String defaultValue) {
@@ -83,8 +82,7 @@ public class MariaDbController {
         }
     }
 
-    public static String getDBPassword() {
-        Properties props = OpenmrsUtil.getRuntimeProperties(StandaloneUtil.getContextName());
-        return props.getProperty("connection.password", DEFAULT_PASSWORD); // fallback to default
+    public static String getRootPassword() {
+        return ROOT_PASSWORD;
     }
 }

--- a/src/main/java/org/openmrs/standalone/MariaDbController.java
+++ b/src/main/java/org/openmrs/standalone/MariaDbController.java
@@ -63,16 +63,8 @@ public class MariaDbController {
         mariaDB.run("ALTER USER 'root'@'localhost' IDENTIFIED BY '" + DEFAULT_ROOT_PASSWORD + "';");
         mariaDB.run("GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;");
 
-        // Create or update the 'openmrs' user with the configured password
-        mariaDB.run("CREATE USER IF NOT EXISTS '" + DATABASE_USER_NAME + "'@'localhost' IDENTIFIED BY '" + userPassword + "';");
-        mariaDB.run("ALTER USER '" + DATABASE_USER_NAME + "'@'localhost' IDENTIFIED BY '" + userPassword + "';");
-
-        // Grant privileges to openmrs user
-        mariaDB.run("GRANT ALL PRIVILEGES ON *.* TO '" + DATABASE_USER_NAME + "'@'localhost';");
-        mariaDB.run("FLUSH PRIVILEGES;");
-
         // Create the OpenMRS database schema if it doesn't exist
-        mariaDB.createDB(DATABASE_NAME, DATABASE_USER_NAME, userPassword);
+        mariaDB.createDB(DATABASE_NAME, "root", "rootpass");
     }
 
     private static String safeResolveProperty(Properties properties, String key, String defaultValue) {

--- a/src/main/java/org/openmrs/standalone/StandaloneUtil.java
+++ b/src/main/java/org/openmrs/standalone/StandaloneUtil.java
@@ -54,7 +54,8 @@ public class StandaloneUtil {
 	 * The maximum number of server port number.
 	 */
 	public static final int MAX_PORT_NUMBER = 49151;
-	
+	private static final String ROOT_USER = "root";
+
 	private static String CONTEXT_NAME;
 
 	static Properties properties = OpenmrsUtil.getRuntimeProperties(StandaloneUtil.getContextName());
@@ -325,7 +326,7 @@ public class StandaloneUtil {
 
 			String sql = "ALTER USER '" + username + "'@'localhost' IDENTIFIED BY '" + newPassword + "';";
 
-			try (Connection connection = DriverManager.getConnection(url,"root", "rootpass");
+			try (Connection connection = DriverManager.getConnection(url, ROOT_USER, MariaDbController.getRootPassword());
 				 Statement statement = connection.createStatement()) {
 
 				statement.execute(sql); // Change password
@@ -427,14 +428,13 @@ public class StandaloneUtil {
 
 		Properties props = OpenmrsUtil.getRuntimeProperties(getContextName());
 		String url = props.getProperty("connection.url");
-		String username = props.getProperty("connection.username");
 		String password = props.getProperty("connection.password");
 
 		System.out.println("Starting MariaDB on port " + mariaDBPort + "...");
 		MariaDbController.startMariaDB(mariaDBPort, password);
 
 		System.out.println("Attempting to connect to the database: " + url);
-		try (Connection conn = DriverManager.getConnection(url, "root", "rootpass");
+		try (Connection conn = DriverManager.getConnection(url, ROOT_USER, MariaDbController.getRootPassword());
 			 Statement stmt = conn.createStatement()) {
 
 			// Check if connection is valid
@@ -442,7 +442,7 @@ public class StandaloneUtil {
 				String createUserSQL = "CREATE USER IF NOT EXISTS 'openmrs'@'localhost' IDENTIFIED BY 'test';";
 				stmt.executeUpdate(createUserSQL);
 
-				// Only grant on openmrs DB wit
+				// Only grant on openmrs DB
 				String grantPrivilegesSQL = "GRANT ALL PRIVILEGES ON `openmrs`.* TO 'openmrs'@'localhost' WITH GRANT OPTION;";
 
 				stmt.executeUpdate(grantPrivilegesSQL);

--- a/src/test/java/org/openmrs/standalone/MariaDbControllerTest.java
+++ b/src/test/java/org/openmrs/standalone/MariaDbControllerTest.java
@@ -66,7 +66,7 @@ public class MariaDbControllerTest {
             when(OpenmrsUtil.getRuntimeProperties(anyString())).thenReturn(properties);
             when(OpenmrsUtil.getRuntimeProperties(Mockito.nullable(String.class))).thenReturn(properties);
 
-            MariaDbController.startMariaDB(MARIADB_PORT, MariaDbController.getDBPassword());
+            MariaDbController.startMariaDB(MARIADB_PORT, ROOT_PASSWORD);
 
             validateMariaDBRunning();
 

--- a/src/test/java/org/openmrs/standalone/StandaloneUtilTest.java
+++ b/src/test/java/org/openmrs/standalone/StandaloneUtilTest.java
@@ -41,6 +41,7 @@ class StandaloneUtilTest {
 
     private static final String MARIADB_BASEDIR_NAME = "mariadb-base-dir";
     private static final String DATA_DIR_NAME = "data";
+    private static final String ROOT_USER = "root";
 
     private Properties properties;
     private Path tempBaseDir;
@@ -80,7 +81,7 @@ class StandaloneUtilTest {
             StandaloneUtil.startupDatabaseToCreateDefaultUser(MARIADB_PORT);
 
             MariaDbController.startMariaDB(MARIADB_PORT, properties.getProperty("connection.password", ""));
-            try (Connection connection = DriverManager.getConnection(DEFAULT_URL, "root", "rootpass")) {
+            try (Connection connection = DriverManager.getConnection(DEFAULT_URL, ROOT_USER, MariaDbController.getRootPassword())) {
 
                 assertNotNull(connection, "Connection to MariaDB with 'root' user should not be null");
                 assertFalse(connection.isClosed(), "Connection to MariaDB should be open");
@@ -104,8 +105,8 @@ class StandaloneUtilTest {
                         String grant = resultSet.getString(1);
                         // Check if the grant statement contains the expected privileges
                         if (grant.toLowerCase().contains("grant create user on *.* to") &&
-                                grant.contains("openmrs") &&
-                                grant.contains("localhost")) {
+                                grant.toLowerCase().contains("openmrs") &&
+                                grant.toLowerCase().contains("localhost")) {
                             privilegesCorrect = true;
                             break;
                         }

--- a/src/test/java/org/openmrs/standalone/StandaloneUtilTest.java
+++ b/src/test/java/org/openmrs/standalone/StandaloneUtilTest.java
@@ -33,7 +33,7 @@ class StandaloneUtilTest {
     private static final String KEY_RESET_CONNECTION_PASSWORD = "reset_connection_password";
     private static final String KEY_CONNECTION_URL = "connection.url";
     private static final String KEY_CONNECTION_USERNAME = "connection.username";
-    private static final String TEST_PASSWORD = "";
+    private static final String TEST_PASSWORD = "test";
 
     private static final String USERNAME = "openmrs";
     private static final String MARIADB_PORT = "33126";
@@ -82,7 +82,7 @@ class StandaloneUtilTest {
             MariaDbController.startMariaDB(MARIADB_PORT, properties.getProperty("connection.password", ""));
             try (Connection connection = DriverManager.getConnection(DEFAULT_URL, "root", "rootpass")) {
 
-                assertNotNull(connection, "Connection to MariaDB with 'openmrs' user should not be null");
+                assertNotNull(connection, "Connection to MariaDB with 'root' user should not be null");
                 assertFalse(connection.isClosed(), "Connection to MariaDB should be open");
 
                 try (Statement stmt = connection.createStatement()) {
@@ -102,7 +102,10 @@ class StandaloneUtilTest {
                     boolean privilegesCorrect = false;
                     while (resultSet.next()) {
                         String grant = resultSet.getString(1);
-                        if (grant.equals("GRANT ALL PRIVILEGES ON *.* TO `openmrs`@`localhost`")) {
+                        // Check if the grant statement contains the expected privileges
+                        if (grant.toLowerCase().contains("grant create user on *.* to") &&
+                                grant.contains("openmrs") &&
+                                grant.contains("localhost")) {
                             privilegesCorrect = true;
                             break;
                         }


### PR DESCRIPTION
See https://openmrs.atlassian.net/browse/STAND-114

## Description
This PR improves **Expert Mode** support during the initialization of OpenMRS Standalone by adjusting how database users and privileges are configured using the embedded MariaDB4j instance. It addresses issues that prevented successful setup when Expert Mode is selected, especially around permission errors like Access denied during `CREATE USER` or `GRANT` operations.

## Screen Recording
[Screencast from 25-06-25 18:39:35.webm](https://github.com/user-attachments/assets/bd4a160d-8d21-4971-a32a-b91204a1cc75)

