### PR TITLE
STAND-118: Supporting mvn  package -Dopenmrs.version without failures

### DIFF
--- a/pom-step-02.xml
+++ b/pom-step-02.xml
@@ -35,13 +35,6 @@
 							<goal>start</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>stop-empty-database</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -46,15 +46,8 @@
 
 				<executions>
 					<execution>
-						<id>start-empty-database</id>
-						<phase>initialize</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-					</execution>
-					<execution>
 						<id>stop-empty-database</id>
-						<phase>process-resources</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>stop</goal>
 						</goals>

--- a/pom-step-04.xml
+++ b/pom-step-04.xml
@@ -35,13 +35,6 @@
 							<goal>start</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>stop-demo-database</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -46,15 +46,8 @@
 
 				<executions>
 					<execution>
-						<id>start-demo-database</id>
-						<phase>initialize</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-					</execution>
-					<execution>
 						<id>stop-demo-database</id>
-						<phase>process-resources</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>stop</goal>
 						</goals>


### PR DESCRIPTION
See https://openmrs.atlassian.net/browse/STAND-118

## Description
This PR addresses the failures caused when running `mvn package -Dopenmrs.version=2.8.0-SNAPSHOT` due to stopping the mariadb early on each module step