### PR TITLE
STAND-120: Move Demo and CIEL Database Packaging from Build-Time to Runtime Platform

### DIFF
--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -27,8 +27,13 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Install MySQL client
-        run: sudo apt-get install mysql-client
+      - name: Install MySQL client (with mysqldump)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client
+
+      - name: Check mysqldump version
+        run: mysqldump --version
 
       - name: Run Maven Install
         run: mvn install

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -27,14 +27,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Install MySQL client (with mysqldump)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client
-
-      - name: Check mysqldump version
-        run: mysqldump --version
-
       - name: Run Maven Install
         run: mvn install
 
@@ -51,10 +43,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Install MySQL Client
-        shell: powershell
-        run: choco install mysql
 
       - name: Run Maven Clean
         run: mvn clean
@@ -74,10 +62,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Install MySQL client (for mysqldump)
-        run: |
-          brew install mysql
 
       - name: Run Maven Clean
         run: mvn clean

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -28,9 +28,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Install MySQL client
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client        
+        run: sudo apt-get install mysql-client
 
       - name: Run Maven Install
         run: mvn install
@@ -51,9 +49,7 @@ jobs:
 
       - name: Install MySQL Client
         shell: powershell
-        run: |
-          choco install mysql --version=8.0.31 --no-progress
-          $env:Path += ";C:\Program Files\MySQL\MySQL Server 8.0\bin"
+        run: choco install mysql
 
       - name: Run Maven Clean
         run: mvn clean

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -47,10 +47,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Install MySQL Client
-        shell: powershell
-        run: choco install mysql
-
       - name: Run Maven Clean
         run: mvn clean
 
@@ -69,10 +65,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Install MySQL client (for mysqldump)
-        run: |
-          brew install mysql
 
       - name: Run Maven Clean
         run: mvn clean

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -27,8 +27,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Run Maven Clean
-        run: mvn clean
+      - name: Install MySQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client        
 
       - name: Run Maven Install
         run: mvn install
@@ -46,6 +48,12 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+
+      - name: Install MySQL Client
+        shell: powershell
+        run: |
+          choco install mysql --version=8.0.31 --no-progress
+          $env:Path += ";C:\Program Files\MySQL\MySQL Server 8.0\bin"
 
       - name: Run Maven Clean
         run: mvn clean
@@ -65,6 +73,10 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+
+      - name: Install MySQL client (for mysqldump)
+        run: |
+          brew install mysql
 
       - name: Run Maven Clean
         run: mvn clean

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Depending on what OpenMRS software artifact you are releasing, you may need to c
 * If you are building OpenMRS Platform => use the `master` branch
 * If you are building OpenMRS Reference Application => use the `openmrs-emr2` branch
 
-## Building openmrs-standalone for OpenMRS version 2.4 or later
+## Building openmrs-standalone for OpenMRS version 2.7 or later
 
 ### Increasing maven memory
 
@@ -30,16 +30,14 @@ argument to use --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED
 
 Building openmrs-standalone is decomposed into five steps as different steps use different version of the Liquibase Maven plugin.
 
-Openmrs-core is using Liquibase 3.x as of OpenMRS version 2.4.x. However, Liquibase version 3.x *fails* to load
-large sql files such as the CIEL concept dictionary. Liquibase version 2.x successfully loads large sql files.
+Openmrs-core is using Liquibase 4.x as of OpenMRS version 2.6.x. However, Liquibase version 4.x *fails* to load
+large sql files such as the CIEL concept dictionary. instead we use the script runner tracing in DbInitializer which loads large sql files.
 
-* Steps 1, 3, and 5 use version 3.10.2 of the plugin as they depend on openmrs-core version 2.4.x  or later.
-
-* Steps 2 and 4 load large sql files and continue to use Liquibase version 2.0.1.
+* Steps 1, 3, and 5 use version 4.32.0 of the plugin as they depend on openmrs-core version 2.7.x  or later.
 
 When running
  
-    $ mvn clean package -Dopenmrs.version=2.4.0
+    $ mvn clean package -Dopenmrs.version=2.7.4-SNAPSHOT
 
 the `clean` step is executed for each module. This means that the folder 
 
@@ -50,7 +48,7 @@ is deleted at the beginning of step 2 and the database created in step 1 is no l
 To avoid that, `mvn clean` needs to be run separately before the rest of the build:
 
     $ mvn clean
-    $ mvn package -Dopenmrs.version=2.4.0
+    $ mvn package -Dopenmrs.version=2.7.4-SNAPSHOT
     
 ### Choosing demo data
 
@@ -65,17 +63,17 @@ just downloaded
 
 ### Choosing CIEL data
 
-* Download the latest CIEL for OpenMRS 1.9.x (use 1.9.x regardless of the maintenance release version) as described [here](https://wiki.openmrs.org/x/ww4JAg).
+* Download the latest CIEL for OpenMRS 2.5.5 (use 2.5.x regardless of the maintenance release version) as described [here](https://wiki.openmrs.org/x/ww4JAg).
 
 * Upload it to mavenrepo by running (adjust the version and the file parameters to match the downloaded version of CIEL):
-`mvn deploy:deploy-file -DgroupId=org.openmrs.contrib -DartifactId=ciel-dictionary -Dversion=1.9.9-20170409 -Dpackaging=zip -Dfile=openmrs_concepts_1.9.9_20170409.sql.zip -DrepositoryId=openmrs-repo-contrib -Durl=https://mavenrepo.openmrs.org/nexus/content/repositories/contrib`
+`mvn deploy:deploy-file -DgroupId=org.openmrs.contrib -DartifactId=ciel-dictionary -Dversion=2.5.5-20250512 -Dpackaging=zip -Dfile=openmrs_concepts_2.5.5_20250512.sql.zip -DrepositoryId=openmrs-repo-contrib -Durl=https://mavenrepo.openmrs.org/nexus/content/repositories/contrib`
 
 * Update the CIEL version in pom.xml.
 
 ### Other tips 
 
-* If running `mvn clean` and `mvn package` second time, ALWAYS check to make sure mariaDB processes on port 3326 and/or 
-3328 and/or 33326 are stopped. If you DON'T do that, then the `mvn clean` will not really clean.
+* If running `mvn clean` and `mvn package` second time, ALWAYS check to make sure mariaDB processes on port 3316 and/or
+  33326 and/or 33328 are stopped. If you DON'T do that, then the `mvn clean` will not really clean.
 
 * A good command to use is: "pkill -f standalone"  (kills anything with "standalone" in the path) 
 
@@ -86,7 +84,7 @@ permission failures since by default linux may fail to modify privileges on non 
 -> output is in the target folder, as openmrs-standalone-(openmrs.version).zip
 -> the contents of that zip are in the similarly-named folder under /target, if you want to test in-place
 
-## Building openmrs-standalone for OpenMRS version 2.3 or earlier
+## Building openmrs-standalone for OpenMRS version 2.7 or earlier
 
 Please note that this version of openmrs-standalone cannot be used for openmrs-core 2.3.x or earlier. 
 
@@ -207,7 +205,7 @@ NOTE: Without this folder structure, you will get errors while trying to run the
 * contextname-runtime.properties 
  * e.g openmrs-runtime.properties, openmrs-1.6.1-runtime.properties, openmrs-1.9.0-runtime.properties, etc
  * If you want to use this runtime properties file, make sure that the web application context name does not match with any existing runtime properties file in say the user's home folder. This is because of the openmrs runtime properties file search order which will only look in the current application folder as the last resort if no runtime properties file has been found in any of the other possible locations.
-* standalone-0.0.1-SNAPSHOT.jar
+* standalone.jar
  * This is the output executable jar for this standalone project.
  * You can build this right from eclipse by right clicking on the project and then select Export -> Java -> Runnable JAR file.
  * The name of this jar file needs to be standalone-0.0.1-SNAPSHOT.jar because it is hard coded in the Bootstrap class as so.
@@ -235,14 +233,6 @@ NOTE: When creating a new database using the openmrs database setup wizard, reme
 	  
 	  The embedded MariaDB4j database engine is a fully functional database engine that you can connect too using any database 
 	  GUI query tools like Navicat, EMS MySQL Manager, etc
-
-
-
-
- 
- 
-
-
 	  
 ## SOME ROUGH STATISTICS SO FAR
 

--- a/pom-step-01.xml
+++ b/pom-step-01.xml
@@ -139,7 +139,7 @@
 				<plugin>
 					<groupId>org.liquibase</groupId>
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
-					<version>${liquibase.plugin.version.3.x}</version>
+					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.api</groupId>

--- a/pom-step-01.xml
+++ b/pom-step-01.xml
@@ -52,13 +52,6 @@
 							<goal>start</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>stop-empty-database</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/pom-step-02.xml
+++ b/pom-step-02.xml
@@ -16,6 +16,23 @@
 		<relativePath>pom.xml</relativePath>
 	</parent>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<version>${openmrs.version}</version>
+			<type>jar</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openmrs.distro</groupId>
+			<artifactId>platform</artifactId>
+			<version>${openmrs.version}</version>
+			<type>war</type>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -138,12 +155,6 @@
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
 					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
-						<dependency>
-							<groupId>org.openmrs.api</groupId>
-							<artifactId>openmrs-api</artifactId>
-							<version>${openmrs.version}</version>
-							<type>jar</type>
-						</dependency>
 						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>
 							<artifactId>modify-column</artifactId>

--- a/pom-step-02.xml
+++ b/pom-step-02.xml
@@ -136,7 +136,7 @@
 				<plugin>
 					<groupId>org.liquibase</groupId>
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
-					<version>${liquibase.plugin.version.3.x}</version>
+					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>

--- a/pom-step-02.xml
+++ b/pom-step-02.xml
@@ -139,6 +139,12 @@
 					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
+							<groupId>org.openmrs.api</groupId>
+							<artifactId>openmrs-api</artifactId>
+							<version>${openmrs.version}</version>
+							<type>jar</type>
+						</dependency>
+						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>
 							<artifactId>modify-column</artifactId>
 							<version>2.0.2</version>

--- a/pom-step-02.xml
+++ b/pom-step-02.xml
@@ -26,16 +26,6 @@
 					<baseDir>${project.build.directory}/emptydatabase</baseDir>
 					<dataDir>${project.build.directory}/emptydatabase/data</dataDir>
 				</configuration>
-
-				<executions>
-					<execution>
-						<id>start-empty-database</id>
-						<phase>initialize</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -75,7 +75,7 @@
 				<executions>
 					<execution>
 						<id>dump-empty-database</id>
-						<phase>verify</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>java</goal>
 						</goals>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -80,14 +80,13 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>mysqldump</executable>
+							<executable>${project.build.directory}/emptydatabase/bin/mariadb-dump</executable>
 							<arguments>
 								<argument>--host=127.0.0.1</argument>
 								<argument>--port=33326</argument>
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
-								<argument>--column-statistics=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
 							</arguments>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -80,16 +80,15 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>sh</executable>
+							<executable>mysqldump</executable>
 							<arguments>
-								<argument>-c</argument>
-								<argument>
-									<![CDATA[
-									  DUMP=$(command -v mysqldump)
-									  if [ -z "$DUMP" ]; then echo "❌ mysqldump not found"; exit 1; fi
-									  "$DUMP" --host=127.0.0.1 --port=33326 --user=openmrs --password=test --skip-lock-tables openmrs --result-file=target/openmrs-empty-dump.sql
-									]]>
-								</argument>
+								<argument>--host=127.0.0.1</argument>
+								<argument>--port=33326</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -36,25 +36,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>ch.vorburger.mariaDB4j</groupId>
-				<artifactId>mariaDB4j-maven-plugin</artifactId>
-				<configuration>
-					<port>33326</port>
-					<baseDir>${project.build.directory}/emptydatabase</baseDir>
-					<dataDir>${project.build.directory}/emptydatabase/data</dataDir>
-				</configuration>
-
-				<executions>
-					<execution>
-						<id>stop-empty-database</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.liquibase</groupId>
 				<artifactId>${liquibase.plugin.artifactId}</artifactId>
 				<executions>
@@ -82,6 +63,53 @@
 						</configuration>
 						<goals>
 							<goal>update</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Exec: Empty Dump DB to SQL -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dump-empty-database</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mysqldump</executable>
+							<arguments>
+								<argument>--host=127.0.0.1</argument>
+								<argument>--port=33326</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>ch.vorburger.mariaDB4j</groupId>
+				<artifactId>mariaDB4j-maven-plugin</artifactId>
+				<configuration>
+					<port>33326</port>
+					<baseDir>${project.build.directory}/emptydatabase</baseDir>
+					<dataDir>${project.build.directory}/emptydatabase/data</dataDir>
+				</configuration>
+
+				<executions>
+					<execution>
+						<id>stop-empty-database</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>stop</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -88,6 +88,7 @@
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
+								<argument>--skip-extended-insert</argument>
 								<argument>--ssl=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -80,15 +80,16 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>mysqldump</executable>
+							<executable>sh</executable>
 							<arguments>
-								<argument>--host=127.0.0.1</argument>
-								<argument>--port=33326</argument>
-								<argument>--user=openmrs</argument>
-								<argument>--password=test</argument>
-								<argument>--skip-lock-tables</argument>
-								<argument>openmrs</argument>
-								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
+								<argument>-c</argument>
+								<argument>
+									<![CDATA[
+									  DUMP=$(command -v mysqldump)
+									  if [ -z "$DUMP" ]; then echo "❌ mysqldump not found"; exit 1; fi
+									  "$DUMP" --host=127.0.0.1 --port=33326 --user=openmrs --password=test --skip-lock-tables openmrs --result-file=target/openmrs-empty-dump.sql
+									]]>
+								</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -80,15 +80,10 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>${project.build.directory}/emptydatabase/bin/mariadb-dump</executable>
+							<executable>bash</executable>
 							<arguments>
-								<argument>--host=127.0.0.1</argument>
-								<argument>--port=33326</argument>
-								<argument>--user=openmrs</argument>
-								<argument>--password=test</argument>
-								<argument>--skip-lock-tables</argument>
-								<argument>openmrs</argument>
-								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
+								<argument>${basedir}/scripts/empty-dump-wrapper.sh</argument>
+								<argument>${project.build.directory}</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -87,6 +87,7 @@
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
+								<argument>--column-statistics=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
 							</arguments>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -121,7 +121,7 @@
 				<plugin>
 					<groupId>org.liquibase</groupId>
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
-					<version>${liquibase.plugin.version.3.x}</version>
+					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.api</groupId>

--- a/pom-step-03.xml
+++ b/pom-step-03.xml
@@ -77,14 +77,22 @@
 						<id>dump-empty-database</id>
 						<phase>verify</phase>
 						<goals>
-							<goal>exec</goal>
+							<goal>java</goal>
 						</goals>
 						<configuration>
-							<executable>bash</executable>
+							<mainClass>org.openmrs.standalone.DatabaseDumper</mainClass>
 							<arguments>
-								<argument>${basedir}/scripts/empty-dump-wrapper.sh</argument>
 								<argument>${project.build.directory}</argument>
+								<argument>emptydatabase</argument>
+								<argument>--port=33326</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>--ssl=0</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-empty-dump.sql</argument>
 							</arguments>
+							<classpathScope>compile</classpathScope>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom-step-04.xml
+++ b/pom-step-04.xml
@@ -86,6 +86,12 @@
 					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
+							<groupId>org.openmrs.api</groupId>
+							<artifactId>openmrs-api</artifactId>
+							<version>${openmrs.version}</version>
+							<type>jar</type>
+						</dependency>
+						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>
 							<artifactId>modify-column</artifactId>
 							<version>2.0.2</version>

--- a/pom-step-04.xml
+++ b/pom-step-04.xml
@@ -83,7 +83,7 @@
 				<plugin>
 					<groupId>org.liquibase</groupId>
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
-					<version>${liquibase.plugin.version.3.x}</version>
+					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>

--- a/pom-step-04.xml
+++ b/pom-step-04.xml
@@ -16,6 +16,23 @@
 		<relativePath>pom.xml</relativePath>
 	</parent>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<version>${openmrs.version}</version>
+			<type>jar</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openmrs.distro</groupId>
+			<artifactId>platform</artifactId>
+			<version>${openmrs.version}</version>
+			<type>war</type>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -85,12 +102,6 @@
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
 					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
-						<dependency>
-							<groupId>org.openmrs.api</groupId>
-							<artifactId>openmrs-api</artifactId>
-							<version>${openmrs.version}</version>
-							<type>jar</type>
-						</dependency>
 						<dependency>
 							<groupId>org.openmrs.liquibase.ext</groupId>
 							<artifactId>modify-column</artifactId>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -75,7 +75,7 @@
 				<executions>
 					<execution>
 						<id>dump-demo-database</id>
-						<phase>verify</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>java</goal>
 						</goals>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -88,6 +88,7 @@
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
+								<argument>--skip-extended-insert</argument>
 								<argument>--ssl=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -80,16 +80,15 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>sh</executable>
+							<executable>mysqldump</executable>
 							<arguments>
-								<argument>-c</argument>
-								<argument>
-									<![CDATA[
-									  DUMP=$(command -v mysqldump)
-									  if [ -z "$DUMP" ]; then echo "❌ mysqldump not found"; exit 1; fi
-									  "$DUMP" --host=127.0.0.1 --port=33328 --user=openmrs --password=test --skip-lock-tables openmrs --result-file=target/openmrs-demo-dump.sql
-									]]>
-								</argument>
+								<argument>--host=127.0.0.1</argument>
+								<argument>--port=33328</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -80,15 +80,16 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>mysqldump</executable>
+							<executable>sh</executable>
 							<arguments>
-								<argument>--host=127.0.0.1</argument>
-								<argument>--port=33328</argument>
-								<argument>--user=openmrs</argument>
-								<argument>--password=test</argument>
-								<argument>--skip-lock-tables</argument>
-								<argument>openmrs</argument>
-								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
+								<argument>-c</argument>
+								<argument>
+									<![CDATA[
+									  DUMP=$(command -v mysqldump)
+									  if [ -z "$DUMP" ]; then echo "❌ mysqldump not found"; exit 1; fi
+									  "$DUMP" --host=127.0.0.1 --port=33328 --user=openmrs --password=test --skip-lock-tables openmrs --result-file=target/openmrs-demo-dump.sql
+									]]>
+								</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -87,6 +87,7 @@
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
+								<argument>--column-statistics=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
 							</arguments>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -77,14 +77,22 @@
 						<id>dump-demo-database</id>
 						<phase>verify</phase>
 						<goals>
-							<goal>exec</goal>
+							<goal>java</goal>
 						</goals>
 						<configuration>
-							<executable>bash</executable>
+							<mainClass>org.openmrs.standalone.DatabaseDumper</mainClass>
 							<arguments>
-								<argument>${basedir}/scripts/demo-dump-wrapper.sh</argument>
 								<argument>${project.build.directory}</argument>
+								<argument>demodatabase</argument>
+								<argument>--port=33328</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>--ssl=0</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
 							</arguments>
+							<classpathScope>compile</classpathScope>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -36,25 +36,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>ch.vorburger.mariaDB4j</groupId>
-				<artifactId>mariaDB4j-maven-plugin</artifactId>
-				<configuration>
-					<port>33328</port>
-					<baseDir>${project.build.directory}/demodatabase</baseDir>
-					<dataDir>${project.build.directory}/demodatabase/data</dataDir>
-				</configuration>
-
-				<executions>
-					<execution>
-						<id>stop-demo-database</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.liquibase</groupId>
 				<artifactId>${liquibase.plugin.artifactId}</artifactId>
 				<executions>
@@ -82,6 +63,53 @@
 						</configuration>
 						<goals>
 							<goal>update</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Exec: Demo Dump DB to SQL -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dump-demo-database</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mysqldump</executable>
+							<arguments>
+								<argument>--host=127.0.0.1</argument>
+								<argument>--port=33328</argument>
+								<argument>--user=openmrs</argument>
+								<argument>--password=test</argument>
+								<argument>--skip-lock-tables</argument>
+								<argument>openmrs</argument>
+								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>ch.vorburger.mariaDB4j</groupId>
+				<artifactId>mariaDB4j-maven-plugin</artifactId>
+				<configuration>
+					<port>33328</port>
+					<baseDir>${project.build.directory}/demodatabase</baseDir>
+					<dataDir>${project.build.directory}/demodatabase/data</dataDir>
+				</configuration>
+
+				<executions>
+					<execution>
+						<id>stop-demo-database</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>stop</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -137,7 +165,7 @@
 					</execution>
 					<execution>
 						<id>zip-demo-data</id>
-						<phase>package</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>
@@ -165,7 +193,7 @@
 					</execution>
 					<execution>
 						<id>zip-standalone</id>
-						<phase>package</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -80,14 +80,13 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>mysqldump</executable>
+							<executable>${project.build.directory}/demodatabase/bin/mariadb-dump</executable>
 							<arguments>
 								<argument>--host=127.0.0.1</argument>
 								<argument>--port=33328</argument>
 								<argument>--user=openmrs</argument>
 								<argument>--password=test</argument>
 								<argument>--skip-lock-tables</argument>
-								<argument>--column-statistics=0</argument>
 								<argument>openmrs</argument>
 								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
 							</arguments>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -222,7 +222,7 @@
 				<plugin>
 					<groupId>org.liquibase</groupId>
 					<artifactId>${liquibase.plugin.artifactId}</artifactId>
-					<version>${liquibase.plugin.version.3.x}</version>
+					<version>${liquibase.plugin.version.4.x}</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.openmrs.api</groupId>

--- a/pom-step-05.xml
+++ b/pom-step-05.xml
@@ -80,15 +80,10 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>${project.build.directory}/demodatabase/bin/mariadb-dump</executable>
+							<executable>bash</executable>
 							<arguments>
-								<argument>--host=127.0.0.1</argument>
-								<argument>--port=33328</argument>
-								<argument>--user=openmrs</argument>
-								<argument>--password=test</argument>
-								<argument>--skip-lock-tables</argument>
-								<argument>openmrs</argument>
-								<argument>--result-file=${project.build.directory}/openmrs-demo-dump.sql</argument>
+								<argument>${basedir}/scripts/demo-dump-wrapper.sh</argument>
+								<argument>${project.build.directory}</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <ciel.dictionary.version>20250512</ciel.dictionary.version>
 
     <liquibase.plugin.artifactId>liquibase-maven-plugin</liquibase.plugin.artifactId>
-    <liquibase.plugin.version.3.x>4.32.0</liquibase.plugin.version.3.x>
+    <liquibase.plugin.version.4.x>4.32.0</liquibase.plugin.version.4.x>
 
     <liquibase.demodata.archive>large-demo-data-2-7-0.sql.zip</liquibase.demodata.archive>
     <liquibase.cieldata.filename>liquibase-ciel-data.xml</liquibase.cieldata.filename>
@@ -207,7 +207,7 @@
                       liquibase-maven-plugin
                     </artifactId>
                     <versionRange>
-                      [${liquibase.plugin.version.3.x},)
+                      [${liquibase.plugin.version.4.x},)
                     </versionRange>
                     <goals>
                       <goal>update</goal>

--- a/scripts/demo-dump-wrapper.sh
+++ b/scripts/demo-dump-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DUMP_BIN="$1/demodatabase/bin/mariadb-dump"
+FALLBACK_BIN="$1/demodatabase/bin/mysqldump"
+
+if [ -x "$DUMP_BIN" ]; then
+  exec "$DUMP_BIN" --user=root --password= --port=33328 openmrs --result-file="$1/openmrs-demo-dump.sql"
+elif [ -x "$FALLBACK_BIN" ]; then
+  exec "$FALLBACK_BIN" --user=root --password= --port=33328 openmrs --result-file="$1/openmrs-demo-dump.sql"
+else
+  echo "❌ No valid dump binary found" >&2
+  exit 1
+fi

--- a/scripts/empty-dump-wrapper.sh
+++ b/scripts/empty-dump-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DUMP_BIN="$1/emptydatabase/bin/mariadb-dump"
+FALLBACK_BIN="$1/emptydatabase/bin/mysqldump"
+
+if [ -x "$DUMP_BIN" ]; then
+  exec "$DUMP_BIN" --user=root --password= --port=33326 openmrs --result-file="$1/openmrs-empty-dump.sql"
+elif [ -x "$FALLBACK_BIN" ]; then
+  exec "$FALLBACK_BIN" --user=root --password= --port=33326 openmrs --result-file="$1/openmrs-empty-dump.sql"
+else
+  echo "❌ No valid dump binary found" >&2
+  exit 1
+fi

--- a/src/main/assembly/zip-ciel-data.xml
+++ b/src/main/assembly/zip-ciel-data.xml
@@ -10,7 +10,10 @@
 	<fileSets>
 		<fileSet>
 			<outputDirectory>/</outputDirectory>
-			<directory>${project.build.directory}/emptydatabase/data</directory>
+			<directory>${project.build.directory}</directory>
+			<includes>
+				<include>openmrs-empty-dump.sql</include>
+			</includes>
 		</fileSet>
 	</fileSets>
 </assembly>

--- a/src/main/assembly/zip-demo-data.xml
+++ b/src/main/assembly/zip-demo-data.xml
@@ -10,7 +10,10 @@
 	<fileSets>
 		<fileSet>
 			<outputDirectory>/</outputDirectory>
-			<directory>${project.build.directory}/demodatabase/data</directory>
+			<directory>${project.build.directory}</directory>
+			<includes>
+				<include>openmrs-demo-dump.sql</include>
+			</includes>
 		</fileSet>
 	</fileSets>
 </assembly>

--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -15,7 +15,13 @@ package org.openmrs.standalone;
 
 import ch.vorburger.exec.ManagedProcessException;
 
-import java.io.*;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Enumeration;
 import java.util.Properties;

--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -256,7 +256,6 @@ public class ApplicationController {
 				deleteActiveDatabase();
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
-				Context.updateSearchIndex();
 				System.out.println("Database mode using wizard: " + applyDatabaseChange );
 			} else if (applyDatabaseChange == DatabaseMode.EMPTY_DATABASE) {
 				deleteActiveDatabase();
@@ -270,6 +269,7 @@ public class ApplicationController {
 				unzipDatabase(new File("demodatabase.zip"));
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
+				Context.updateSearchIndex();
 				System.out.println("Database mode using demo database: " + applyDatabaseChange );
 			}
 			

--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -14,6 +14,7 @@
 package org.openmrs.standalone;
 
 import ch.vorburger.exec.ManagedProcessException;
+import org.openmrs.api.context.Context;
 
 
 import java.io.BufferedInputStream;
@@ -256,12 +257,14 @@ public class ApplicationController {
 				deleteActiveDatabase();
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
+				Context.updateSearchIndex();
 				System.out.println("Database mode using wizard: " + applyDatabaseChange );
 			} else if (applyDatabaseChange == DatabaseMode.EMPTY_DATABASE) {
 				deleteActiveDatabase();
 				unzipDatabase(new File("emptydatabase.zip"));
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
+				Context.updateSearchIndex();
 				System.out.println("Database mode using empty: " + applyDatabaseChange );
 			} else if (applyDatabaseChange == DatabaseMode.DEMO_DATABASE) {
 				deleteActiveDatabase();

--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -15,12 +15,7 @@ package org.openmrs.standalone;
 
 import ch.vorburger.exec.ManagedProcessException;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -28,6 +23,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static org.openmrs.standalone.MariaDbController.stopMariaDB;
+import static org.openmrs.standalone.OpenmrsUtil.importSqlFile;
 
 /**
  * Manages the application workflow.

--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -30,7 +30,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static org.openmrs.standalone.MariaDbController.stopMariaDB;
-import static org.openmrs.standalone.OpenmrsUtil.importSqlFile;
 
 /**
  * Manages the application workflow.

--- a/src/main/java/org/openmrs/standalone/DatabaseDumper.java
+++ b/src/main/java/org/openmrs/standalone/DatabaseDumper.java
@@ -1,0 +1,40 @@
+package org.openmrs.standalone;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openmrs.standalone.OpenmrsUtil.findDumpExecutable;
+
+public class DatabaseDumper {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("Usage: java DatabaseDumper <baseDir> [mariadb-dump args...]");
+            System.exit(1);
+        }
+
+        String baseDir = args[0];
+        String dbDir = args[1];
+        String executable = findDumpExecutable(baseDir, dbDir);
+
+        List<String> command = new ArrayList<>();
+        command.add(executable);
+
+        // Add all remaining args starting from args[2], which are the dump flags and db name
+        for (int i = 2; i < args.length; i++) {
+            command.add(args[i]);
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(new File("."));
+        pb.inheritIO();
+
+        Process process = pb.start();
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("Dump command failed with exit code: " + exitCode);
+        }
+
+        System.out.println("✅ Dump completed successfully.");
+    }
+}

--- a/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
+++ b/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
@@ -231,7 +231,7 @@ public class OpenmrsUtil {
 	 * Convenience method used to load properties from the given file.
 	 * 
 	 * @param props the properties object to be loaded into
-	 * @param propertyFile the properties file to read
+	 * @param inputStream the properties file to read
 	 */
 	private static void loadProperties(Properties props, InputStream inputStream) {
 		try {

--- a/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
+++ b/src/main/java/org/openmrs/standalone/OpenmrsUtil.java
@@ -24,6 +24,8 @@ import java.io.UnsupportedEncodingException;
 import java.io.File;
 import java.io.Reader;
 import java.io.FileReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.Properties;
@@ -296,6 +298,19 @@ public class OpenmrsUtil {
 		} catch (Exception e) {
 			System.err.println("❌ Error importing SQL: " + e.getMessage());
 			e.printStackTrace();
+		}
+	}
+
+	public static String findDumpExecutable(String baseDir, String dbDir) {
+		String os = System.getProperty("os.name").toLowerCase();
+		boolean isWindows = os.contains("win");
+
+		Path mariadbDump = Paths.get(baseDir, dbDir, "bin", isWindows ? "mysqldump.exe" : "mariadb-dump");
+
+		if (mariadbDump.toFile().exists()) {
+			return mariadbDump.toString();
+		} else {
+			throw new RuntimeException("❌ Neither mariadb-dump nor mysqldump found in: " + mariadbDump.getParent());
 		}
 	}
 

--- a/src/main/java/org/openmrs/standalone/StandaloneUtil.java
+++ b/src/main/java/org/openmrs/standalone/StandaloneUtil.java
@@ -452,17 +452,18 @@ public class StandaloneUtil {
 
 				// Find sql if exist to preload DB
 				File dataDir = new File("database/data");
-				// Find the first .sql file in the unzipped folder
-				File[] sqlFiles = dataDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".sql"));
-				if (sqlFiles == null || sqlFiles.length == 0) {
-					throw new FileNotFoundException("No .sql file found in: " + dataDir.getAbsolutePath());
+
+				if (dataDir.exists() && dataDir.isDirectory()) {
+					// Find the first .sql file in the unzipped folder
+					File[] sqlFiles = dataDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".sql"));
+					if (sqlFiles != null && sqlFiles.length != 0) {
+						// Run the first found SQL file
+						File sqlFile = sqlFiles[0];
+
+						System.out.println(url + " :us : " + username + " :ps : " + password);
+						importSqlFile(sqlFile, url, username, password);
+					}
 				}
-
-				// Run the first found SQL file
-				File sqlFile = sqlFiles[0];
-
-				System.out.println(url + " :us : " + username + " :ps : " + password);
-				importSqlFile(sqlFile, url, username, password);
 			} else {
 				System.err.println("❌ Connection established, but it is not valid.");
 			}

--- a/src/main/java/org/openmrs/standalone/StandaloneUtil.java
+++ b/src/main/java/org/openmrs/standalone/StandaloneUtil.java
@@ -459,8 +459,6 @@ public class StandaloneUtil {
 					if (sqlFiles != null && sqlFiles.length != 0) {
 						// Run the first found SQL file
 						File sqlFile = sqlFiles[0];
-
-						System.out.println(url + " :us : " + username + " :ps : " + password);
 						importSqlFile(sqlFile, url, username, password);
 					}
 				}


### PR DESCRIPTION
See https://openmrs.atlassian.net/browse/STAND-120

## Description

This task migrates the packaging of demo and CIEL database artifacts from Maven build-time (maven-assembly-plugin) to runtime handling. Instead of generating and zipping SQL files (demodatabase.zip, emptydatabase.zip) during the build phase, the system will now handle:

Extraction of .sql files from packaged resources or external directories at runtime.

Automatic execution/import of these SQL files into the embedded MariaDB instance via ScriptRunner during startup.

## Screen Record

https://github.com/user-attachments/assets/dfe585db-8f7b-41ff-843e-be4c7957747d

