### PR TITLE
STAND-134: Fix org.springframework.beans.factory.BeanCreationException in 2.x ReffApp Standalone

### DIFF
--- a/src/main/config/openmrs-runtime.properties
+++ b/src/main/config/openmrs-runtime.properties
@@ -10,6 +10,6 @@ connection.password=test
 tomcatport=8081
 application_data_directory=appdata
 reset_connection_password=true
-vm_arguments=-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED
+vm_arguments=-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
 # Tell MariaDB where to find database files (this is the important part!)
 connection.database.data_dir=./database/data


### PR DESCRIPTION
## Issue
https://openmrs.atlassian.net/browse/STAND-134
## Description
This PR fixes a startup failure in Reference Application Standalone caused by Spring AOP / CGLIB being unable to proxy `ObsServiceImpl` when running on Java 17+.

## Screenshot before fix
<img width="1920" height="1080" alt="Screenshot from 2025-08-24 20-31-36" src="https://github.com/user-attachments/assets/662736bd-cfca-47ce-9482-c8ef01a58a88" />

## Screenshot After fix
<img width="1920" height="1080" alt="Screenshot from 2025-08-26 10-00-26" src="https://github.com/user-attachments/assets/6f996bf6-ddd5-46a1-b92f-70a5260c6a4c" />
