### PR TITLE
Update default versions to OpenMRS Core 2.8.4 and RefApp 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 		<liquibase.plugin.version>4.23.2</liquibase.plugin.version>
 
 		<tomcat.version>9.0.106</tomcat.version>
-		<openmrs.version>2.8.4-SNAPSHOT</openmrs.version>
-		<refapp.version>3.6.0-SNAPSHOT</refapp.version>
+		<openmrs.version>2.8.4</openmrs.version>
+		<refapp.version>3.6.0</refapp.version>
 		<mariadb4jVersion>3.2.0</mariadb4jVersion>
 		<junitVersion>5.12.2</junitVersion>
 		<mockitoVersion>3.12.4</mockitoVersion>


### PR DESCRIPTION
## Summary

Switches the default version properties in `pom.xml` from SNAPSHOT to released versions:

- `openmrs.version`: `2.8.4-SNAPSHOT` → `2.8.4`
- `refapp.version`: `3.6.0-SNAPSHOT` → `3.6.0`

This allows `mvn package` to build the standalone zip against the released artifacts without needing to pass `-D` overrides.