### PR TITLE
Fix Infinispan/Java 21+ startup failure by disabling Hibernate L2 cache

### DIFF
--- a/src/main/config/openmrs-runtime.properties
+++ b/src/main/config/openmrs-runtime.properties
@@ -15,3 +15,4 @@ vm_arguments=-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.a
 connection.database.data_dir=./database/data
 hibernate.connection.driver_class=org.mariadb.jdbc.Driver
 hibernate.dialect=org.hibernate.dialect.MariaDBDialect
+hibernate.cache.use_second_level_cache=false

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -97,7 +97,7 @@ public class Bootstrap {
 		
 		try {	
 			Properties properties = OpenmrsUtil.getRuntimeProperties(StandaloneUtil.getContextName());
-			String vm_arguments = properties.getProperty("vm_arguments", "-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED");
+			String vm_arguments = properties.getProperty("vm_arguments", "-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED");
 			
 			// Spin up a separate java process calling a non-default Main class in our Jar.  
 			process = Runtime.getRuntime().exec(


### PR DESCRIPTION
## Problem

Infinispan 13.0.22 (bundled in OpenMRS Core 2.8.4) calls `Subject.getSubject()` during initialization, which throws `UnsupportedOperationException` on Java 21.0.4+ and is removed entirely in Java 24 (JEP 486).

## Fix

Disable Hibernate L2 cache via `hibernate.cache.use_second_level_cache=false` in the runtime properties. OpenMRS's `HibernateSessionFactoryBean` merges runtime properties into Hibernate config, so this prevents Infinispan from ever initializing.

This is the simpler alternative to #112 (which patches the Infinispan WAR to keep L2 caching). For a standalone/demo distribution the performance impact is negligible.

## Changes

- `src/main/config/openmrs-runtime.properties`: Add `hibernate.cache.use_second_level_cache=false`
- `src/main/java/org/openmrs/standalone/Bootstrap.java`: Sync default vm_arguments to include `--add-opens=java.base/java.lang=ALL-UNNAMED`

## Compatibility

Works on Java 21, 24, 25, and all future versions (no dependency on Security Manager APIs).