### PR TITLE
Fix shutdown cleanup: stop Tomcat before MariaDB, disable reloadable

### DIFF
--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -234,17 +234,17 @@ public class ApplicationController {
 		
 		userInterface.setVisible(true);
 		
-		// add shutdown hook to stop server
+		// add shutdown hook to stop server (Tomcat first, then MariaDB)
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			
 			public void run() {
+				stopServer();
 				try {
 					stopMariaDB();
 				} catch (ManagedProcessException e) {
 					System.out.println("Failed to stop MariaDB: " + e.getMessage());
 					e.printStackTrace();
 				}
-				stopServer();
 			}
 		});
 		

--- a/src/main/java/org/openmrs/standalone/TomcatManager.java
+++ b/src/main/java/org/openmrs/standalone/TomcatManager.java
@@ -74,7 +74,7 @@ public class TomcatManager {
 		String warPath = "tomcat/webapps/" + contextName + ".war";
 		File warFile = new File(warPath);
 		Context rootContext = container.addWebapp("/" + contextName, warFile.getAbsolutePath());
-		rootContext.setReloadable(true);
+		rootContext.setReloadable(false);
 		
 		// create http connector
 		Connector httpConnector = new Connector();
@@ -101,6 +101,7 @@ public class TomcatManager {
 		try {
 			if (container != null) {
 				container.stop();
+				container.destroy();
 				container = null;
 				stopMySql = true;
 			}


### PR DESCRIPTION
## Problem

During shutdown, errors like `NoSuchFileException: .../WEB-INF/lib/httpcore-nio-4.4.13.jar` occur because:

1. **Shutdown hook stops MariaDB before Tomcat** — the database is killed while Tomcat is still running context cleanup listeners (`Listener.contextDestroyed()`), which try to open Hibernate sessions and load classes
2. **`reloadable=true`** causes unnecessary filesystem monitoring of WEB-INF/lib JARs, increasing the chance of classloader issues during shutdown
3. **Missing `container.destroy()`** means Tomcat resources aren't fully released after stop

## Changes

- **Fix shutdown hook order**: Stop Tomcat first, then MariaDB — ensures Tomcat can cleanly finish context destruction before the database is killed
- **Set `reloadable=false`**: Hot-reloading is unnecessary for a standalone distribution
- **Call `container.destroy()` after `container.stop()`**: Proper Tomcat lifecycle cleanup (stop halts components, destroy releases resources)