### PR TITLE
Add JVM flag to allow Subject.getSubject() for Infinispan compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ local.properties
 
 # PDT-specific
 .buildpath
+.DS_Store

--- a/src/main/config/openmrs-runtime.properties
+++ b/src/main/config/openmrs-runtime.properties
@@ -10,7 +10,7 @@ connection.password=test
 tomcatport=8081
 application_data_directory=appdata
 reset_connection_password=true
-vm_arguments=-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
+vm_arguments=-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=allow
 # Tell MariaDB where to find database files (this is the important part!)
 connection.database.data_dir=./database/data
 hibernate.connection.driver_class=org.mariadb.jdbc.Driver

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -97,7 +97,7 @@ public class Bootstrap {
 		
 		try {	
 			Properties properties = OpenmrsUtil.getRuntimeProperties(StandaloneUtil.getContextName());
-			String vm_arguments = properties.getProperty("vm_arguments", "-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED");
+			String vm_arguments = properties.getProperty("vm_arguments", "-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=allow");
 			
 			// Spin up a separate java process calling a non-default Main class in our Jar.  
 			process = Runtime.getRuntime().exec(


### PR DESCRIPTION
## Problem

Oracle JDK 21.0.6 backported [JDK-8296244](https://bugs.openjdk.org/browse/JDK-8296244) which respecifies `Subject.getSubject(AccessControlContext)` to throw `UnsupportedOperationException` when the Security Manager is not allowed.

Infinispan 13.0.22.Final calls `Subject.getSubject()` during cache initialization (`Security.getSubject()` → `NumericVersionGenerator.start()`), causing the standalone to crash at startup with:

```
Caused by: java.lang.UnsupportedOperationException: getSubject is not supported
    at java.base/javax.security.auth.Subject.getSubject(Subject.java:334)
    at org.infinispan.security.Security.getSubject(Security.java:53)
```

Full error: https://gist.github.com/dkayiwa/63531e800c025877d840965a14a3a61e

## Fix

Per the official workaround documented in [JDK-8328643](https://bugs.openjdk.org/browse/JDK-8328643):

> *The temporary workaround in this release to keep older code working is to run with `-Djava.security.manager=allow` to allow a Security Manager to be set.*

This adds `-Djava.security.manager=allow` to the JVM arguments in both:
- `Bootstrap.java` (default vm_arguments fallback)
- `openmrs-runtime.properties` (the actual vm_arguments used at runtime)

This re-enables `Subject.getSubject()` without actually installing a Security Manager.