### PR TITLE
Regenerate demo DB dump and disable demo data generation at startup

### DIFF
--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -275,6 +275,7 @@ public class ApplicationController {
 			} else if (applyDatabaseChange == DatabaseMode.DEMO_DATABASE) {
 				deleteActiveDatabase();
 				unzipDatabase(new File("demodatabase.zip"));
+				deleteDemoDataModule();
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
 				System.out.println("Database mode using wizard: " + applyDatabaseChange);


### PR DESCRIPTION
## Summary

Two changes that ensure the standalone starts immediately in demo mode:

1. **Regenerated demo-db-3.6.0.sql** with fully initialized demo data (waited for all background tasks including appointment processing to complete)
2. **Delete referencedemodata module** in demo mode since the dump already contains all demo data — prevents redundant regeneration on first startup

## Data in the dump

| Entity | Count |
|--------|-------|
| Concepts | 4,241 |
| Patients | 50 |
| Encounters | 1,157 |
| Observations | 4,720 |
| Visits | 212 |
| Orders | 267 |
| Appointments | 125 |
| Drugs | 323 |
| OCL Imports | 24 (all completed) |

## Code change

```java
// ApplicationController.java - DEMO_DATABASE path now also removes the module
} else if (applyDatabaseChange == DatabaseMode.DEMO_DATABASE) {
    deleteActiveDatabase();
    unzipDatabase(new File("demodatabase.zip"));
    deleteDemoDataModule();  // <-- added
    StandaloneUtil.resetConnectionPassword();
```

This mirrors what the EMPTY_DATABASE path already does.