### PR TITLE
Fix Initializer re-processing config on first startup

### DIFF
--- a/pom-step-01.xml
+++ b/pom-step-01.xml
@@ -98,11 +98,27 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Start Docker Compose and wait to copy checksums-->
+            <!-- Pre-compute configuration checksums and optionally copy from Docker -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>generate-checksums</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <arguments>
+                                <argument>scripts/generate-checksums.sh</argument>
+                                <argument>${project.build.directory}/distro/web/openmrs_config</argument>
+                                <argument>${project.build.directory}/distro/web/openmrs_config_checksums</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>start-docker-and-wait</id>
                         <phase>process-resources</phase>

--- a/scripts/generate-checksums.sh
+++ b/scripts/generate-checksums.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Pre-computes configuration checksums for the Initializer module.
+# This replicates the exact checksum mechanism used by openmrs-module-initializer
+# (ConfigDirUtil.computeChecksum) which is a plain MD5 of the file content.
+#
+# Usage: generate-checksums.sh <config_dir> <checksums_output_dir>
+
+CONFIG_DIR="$1"
+CHECKSUMS_DIR="$2"
+
+if [ -z "$CONFIG_DIR" ] || [ -z "$CHECKSUMS_DIR" ]; then
+    echo "Usage: $0 <config_dir> <checksums_output_dir>"
+    exit 1
+fi
+
+if [ ! -d "$CONFIG_DIR" ]; then
+    echo "❌ Config directory does not exist: $CONFIG_DIR"
+    exit 1
+fi
+
+# Determine md5 command (macOS uses md5, Linux uses md5sum)
+if command -v md5sum &> /dev/null; then
+    md5cmd() { md5sum "$1" | cut -d' ' -f1; }
+elif command -v md5 &> /dev/null; then
+    md5cmd() { md5 -q "$1"; }
+else
+    echo "❌ Neither md5sum nor md5 found!"
+    exit 1
+fi
+
+echo "📦 Generating configuration checksums..."
+echo "   Config dir:    $CONFIG_DIR"
+echo "   Checksums dir: $CHECKSUMS_DIR"
+
+FILE_COUNT=0
+
+for domain_dir in "$CONFIG_DIR"/*/; do
+    [ -d "$domain_dir" ] || continue
+    domain=$(basename "$domain_dir")
+    checksums_domain_dir="$CHECKSUMS_DIR/$domain"
+    mkdir -p "$checksums_domain_dir"
+
+    find "$domain_dir" -type f | while read -r file; do
+        # Compute relative path from domain dir
+        rel_path="${file#$domain_dir}"
+        # Replace / with _ and remove extension (matches Initializer's getLocatedFilename)
+        located_filename=$(echo "$rel_path" | tr '/' '_' | sed 's/\.[^.]*$//')
+        # Compute MD5 (matches Initializer's computeChecksum using MessageDigest MD5)
+        checksum=$(md5cmd "$file")
+        # Write checksum file without trailing newline (matches Initializer's writeChecksum)
+        printf '%s' "$checksum" > "$checksums_domain_dir/${located_filename}.checksum"
+    done
+
+    count=$(find "$checksums_domain_dir" -name "*.checksum" | wc -l | tr -d ' ')
+    FILE_COUNT=$((FILE_COUNT + count))
+done
+
+echo "✅ Generated $FILE_COUNT checksum files across $(ls -d "$CHECKSUMS_DIR"/*/ 2>/dev/null | wc -l | tr -d ' ') domains."

--- a/scripts/start-docker-and-wait.sh
+++ b/scripts/start-docker-and-wait.sh
@@ -38,12 +38,15 @@ echo "✅ OpenMRS is up. Proceeding to copy configuration checksums..."
 
 CONTAINER_ID=$(docker-compose -f "$DISTRO_DIR/docker-compose.yml" ps -q web)
 
-# Try to copy the checksum file
+# Copy checksums from the container. Use trailing /. on source to copy CONTENTS
+# into the destination directory (avoids nesting configuration_checksums/ inside
+# openmrs_config_checksums/ when the destination already exists).
 echo "📦 Attempting to extract openmrs_config_checksums..."
-if docker cp "$CONTAINER_ID":/openmrs/data/configuration_checksums "$DISTRO_DIR/web/openmrs_config_checksums"; then
+mkdir -p "$DISTRO_DIR/web/openmrs_config_checksums"
+if docker cp "$CONTAINER_ID":/openmrs/data/configuration_checksums/. "$DISTRO_DIR/web/openmrs_config_checksums/"; then
   echo "✅ Checksums copied successfully."
 else
-  echo "❌ Failed to copy checksums file. File may not exist yet."
+  echo "⚠️  Failed to copy checksums from Docker. Pre-computed checksums will be used."
 fi
 
 echo "🧹 Shutting down Docker containers..."


### PR DESCRIPTION
## Problem

When the standalone starts for the first time in demo database mode, the Initializer module re-processes all configuration files, causing errors:

1. **CohortType duplicates**: "System List" and "My List" already exist in the demo DB
2. **Address hierarchy config invalid**: Re-processed unnecessarily
3. **OCL concept mapping duplicates**: Re-imports concepts already in the demo DB

## Root Cause

The distribution ZIP shipped with an **empty** `configuration_checksums/` directory. The `docker cp` command in `start-docker-and-wait.sh` nested the source directory inside the destination (creating `openmrs_config_checksums/configuration_checksums/` instead of placing files directly under `openmrs_config_checksums/`). Without matching checksums, the Initializer processes every config file on first startup.

Additionally, in CI builds the Docker step is disabled entirely, so no checksums were ever generated.

## Fix

1. **`scripts/generate-checksums.sh`** (new): Pre-computes MD5 checksums from config files, replicating the Initializer's `ConfigDirUtil.computeChecksum()` logic. Runs during the build after `build-distro` but before assembly, ensuring checksums are always present regardless of whether Docker runs.

2. **`scripts/start-docker-and-wait.sh`**: Fixed `docker cp` to use trailing `/.` on the source path, which copies directory **contents** instead of nesting the directory itself.

3. **`pom-step-01.xml`**: Added `generate-checksums` execution before the Docker step.

This uses the same checksum mechanism that the Initializer module relies on — if the checksum matches, the file is skipped.

**Note:** Two cosmetic errors from webservices.rest module (`CommonsLoggingOutput: Attribute "moduleId" must be declared`) are upstream issues not fixable from the standalone.