### PR TITLE
Replace module deletion with runtime property to disable demo data

### DIFF
--- a/src/main/java/org/openmrs/standalone/ApplicationController.java
+++ b/src/main/java/org/openmrs/standalone/ApplicationController.java
@@ -19,7 +19,6 @@ import org.apache.commons.io.FileUtils;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -268,14 +267,14 @@ public class ApplicationController {
 			} else if (applyDatabaseChange == DatabaseMode.EMPTY_DATABASE) {
 				deleteActiveDatabase();
 				unzipDatabase(new File("emptydatabase.zip"));
-				deleteDemoDataModule();
+				StandaloneUtil.disableDemoDataGeneration();
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
 				System.out.println("Database mode using wizard: " + applyDatabaseChange);
 			} else if (applyDatabaseChange == DatabaseMode.DEMO_DATABASE) {
 				deleteActiveDatabase();
 				unzipDatabase(new File("demodatabase.zip"));
-				deleteDemoDataModule();
+				StandaloneUtil.disableDemoDataGeneration();
 				StandaloneUtil.resetConnectionPassword();
 				StandaloneUtil.startupDatabaseToCreateDefaultUser(mySqlPort);
 				System.out.println("Database mode using wizard: " + applyDatabaseChange);
@@ -499,25 +498,6 @@ public class ApplicationController {
 	 */
 	public void setApplyDatabaseChange(DatabaseMode modeToApply) {
 		this.applyDatabaseChange = modeToApply;
-	}
-	
-	private void deleteDemoDataModule() {
-		File directory = new File("appdata/modules");  
-		   
-		File[] toBeDeleted = directory.listFiles(new FileFilter() {  
-			public boolean accept(File theFile) {  
-				if (theFile.isFile()) {  
-					return (theFile.getName().startsWith("referencedemodata") ||
-							theFile.getName().startsWith("openmrs-webapp"));  
-				}  
-				
-				return false;  
-			}  
-		});  
-		     
-		for (File deletableFile : toBeDeleted) {  
-			deletableFile.delete();  
-		}
 	}
 	
 	private static void writeProcessIdFile() {

--- a/src/main/java/org/openmrs/standalone/StandaloneUtil.java
+++ b/src/main/java/org/openmrs/standalone/StandaloneUtil.java
@@ -415,6 +415,17 @@ public class StandaloneUtil {
 	}
 	
 	/**
+	 * Disables demo data generation by the referencedemodata module.
+	 * The module checks the runtime property "referencedemodata.createDemoPatients"
+	 * and skips patient creation when set to "false".
+	 */
+	public static void disableDemoDataGeneration() {
+		Map<String, String> props = new HashMap<String, String>();
+		props.put("referencedemodata.createDemoPatients", "false");
+		updateRuntimeProperties(props);
+	}
+	
+	/**
 	 * Sets the given runtime properties, and re-saves the file
 	 * 
 	 * @param newProps


### PR DESCRIPTION
## Change

Replaces `deleteDemoDataModule()` (which physically deleted the referencedemodata omod file) with setting the runtime property `referencedemodata.createDemoPatients=false`.

The referencedemodata module's activator checks this property on startup and skips demo patient generation when it is `false`.

## Why

- Cleaner: the module stays installed and can be re-enabled if needed
- Uses the module's own built-in configuration mechanism
- Applies to both DEMO_DATABASE and EMPTY_DATABASE modes (neither needs demo data generated since the demo DB already has it, and the empty DB shouldn't have it)