### PR TITLE
STAND-142: Fix: Enforce Java 17-21 Compatibility and Inherit Java Version

### DIFF
--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -99,9 +99,15 @@ public class Bootstrap {
 			Properties properties = OpenmrsUtil.getRuntimeProperties(StandaloneUtil.getContextName());
 			String vm_arguments = properties.getProperty("vm_arguments", "-Xmx512m -Xms512m -XX:NewSize=128m --add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED");
 
+			String javaHome = System.getProperty("java.home");
+			String javaExecutable = javaHome + java.io.File.separator + "bin" + java.io.File.separator + "java";
+			if (System.getProperty("os.name").toLowerCase().contains("win")) {
+				javaExecutable += ".exe";
+			}
+
 			// Spin up a separate java process calling a non-default Main class in our Jar.  
 			process = Runtime.getRuntime().exec(
-			    "java " + (showSplashScreen ? "-splash:splashscreen-loading.png" : "")
+			    javaExecutable + " " + (showSplashScreen ? "-splash:splashscreen-loading.png" : "")
 			            + " " + vm_arguments + " -cp "
 			            + StandaloneUtil.getJarFileName() + " org.openmrs.standalone.ApplicationController" + args);
 			
@@ -140,6 +146,30 @@ public class Bootstrap {
 	 * @param args the command line arguments.
 	 */
 	public static void main(String[] args) {
+		String javaVersion = System.getProperty("java.version");
+		int majorVersion = 0;
+		try {
+			if (javaVersion.startsWith("1.")) {
+				majorVersion = Integer.parseInt(javaVersion.substring(2, 3));
+			} else {
+				int dot = javaVersion.indexOf(".");
+				majorVersion = dot != -1 ? Integer.parseInt(javaVersion.substring(0, dot)) : Integer.parseInt(javaVersion);
+			}
+		} catch (Exception e) {}
+
+		if (majorVersion < 17 || majorVersion > 23) {
+			String message = "OpenMRS Standalone requires Java 17 through 23 (Java 21 is recommended).\n"
+					+ "You are currently running Java " + javaVersion + ".\n\n"
+					+ (majorVersion > 23 ? "Java 24+ removes security features required by OpenMRS, causing startup failures.\n" : "")
+					+ "Please install a supported Java version and use it to run this application.";
+			try {
+				javax.swing.JOptionPane.showMessageDialog(null, message, "Unsupported Java Version", javax.swing.JOptionPane.ERROR_MESSAGE);
+			} catch (Exception e) {
+				System.err.println(message);
+			}
+			System.exit(1);
+		}
+
 		boolean showSplashScreen = true;
 		
 		String commandLineArguments = "";

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -176,7 +176,8 @@ public class Bootstrap {
 		if (majorVersion < 17 || majorVersion > 21) {
 			String message = "OpenMRS Standalone requires Java 17 through 21 (Java 17 is recommended).\n"
 					+ "You are currently running Java " + javaVersion + ".\n\n"
-					+ (majorVersion > 21 ? "Java 24+ removes security features required by OpenMRS, causing startup failures.\n" : "")
+					+ (majorVersion >= 24 ? "Java 24+ removes security features required by OpenMRS, causing startup failures.\n"
+							: majorVersion > 21 ? "Java versions above 21 are not yet supported by the bundled components.\n" : "")
 					+ "Please install a supported Java version and use it to run this application.";
 			try {
 				javax.swing.JOptionPane.showMessageDialog(null, message, "Unsupported Java Version", javax.swing.JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -164,14 +164,17 @@ public class Bootstrap {
 	public static void main(String[] args) {
 		String javaVersion = System.getProperty("java.version");
 		int majorVersion = 0;
-		try {
-			if (javaVersion.startsWith("1.")) {
-				majorVersion = Integer.parseInt(javaVersion.substring(2, 3));
-			} else {
-				int dot = javaVersion.indexOf(".");
-				majorVersion = dot != -1 ? Integer.parseInt(javaVersion.substring(0, dot)) : Integer.parseInt(javaVersion);
+		if (javaVersion != null) {
+			try {
+				if (javaVersion.startsWith("1.")) {
+					majorVersion = Integer.parseInt(javaVersion.substring(2, 3));
+				} else {
+					majorVersion = Integer.parseInt(javaVersion.split("[\\.-]")[0]);
+				}
+			} catch (Exception e) {
+				System.err.println("Failed to parse java.version: " + javaVersion);
 			}
-		} catch (Exception e) {}
+		}
 
 		if (majorVersion < 17 || majorVersion > 21) {
 			String message = "OpenMRS Standalone requires Java 17 through 21 (Java 17 is recommended).\n"

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -91,7 +91,7 @@ public class Bootstrap {
 	 * @param args the command line arguments.
 	 * @param showSplashScreen determines whether the splashscreen is to be shown.
 	 */
-	private void launch(String args, boolean showSplashScreen) {
+	private void launch(String[] args, boolean showSplashScreen) {
 		
 		Process process = null;
 		
@@ -105,11 +105,27 @@ public class Bootstrap {
 				javaExecutable += ".exe";
 			}
 
+			java.util.List<String> command = new java.util.ArrayList<String>();
+			command.add(javaExecutable);
+			if (showSplashScreen) {
+				command.add("-splash:splashscreen-loading.png");
+			}
+			if (vm_arguments != null && !vm_arguments.trim().isEmpty()) {
+				for (String arg : vm_arguments.trim().split("\\s+")) {
+					command.add(arg);
+				}
+			}
+			command.add("-cp");
+			command.add(StandaloneUtil.getJarFileName());
+			command.add("org.openmrs.standalone.ApplicationController");
+			if (args != null) {
+				for (String arg : args) {
+					command.add(arg);
+				}
+			}
+
 			// Spin up a separate java process calling a non-default Main class in our Jar.  
-			process = Runtime.getRuntime().exec(
-			    javaExecutable + " " + (showSplashScreen ? "-splash:splashscreen-loading.png" : "")
-			            + " " + vm_arguments + " -cp "
-			            + StandaloneUtil.getJarFileName() + " org.openmrs.standalone.ApplicationController" + args);
+			process = Runtime.getRuntime().exec(command.toArray(new String[0]));
 			
 			// Proxy the System.out and System.err from the spawned process back to the main window.  This
 			// is important or the spawned process could block.
@@ -172,10 +188,7 @@ public class Bootstrap {
 
 		boolean showSplashScreen = true;
 		
-		String commandLineArguments = "";
 		for (String arg : args) {
-			commandLineArguments += (" " + arg);
-			
 			if (arg.contains("commandline"))
 				showSplashScreen = false;
 		}
@@ -193,6 +206,6 @@ public class Bootstrap {
 			}
 		});
 		
-		new Bootstrap().launch(commandLineArguments, showSplashScreen);
+		new Bootstrap().launch(args, showSplashScreen);
 	}
 }

--- a/src/main/java/org/openmrs/standalone/Bootstrap.java
+++ b/src/main/java/org/openmrs/standalone/Bootstrap.java
@@ -157,10 +157,10 @@ public class Bootstrap {
 			}
 		} catch (Exception e) {}
 
-		if (majorVersion < 17 || majorVersion > 23) {
-			String message = "OpenMRS Standalone requires Java 17 through 23 (Java 21 is recommended).\n"
+		if (majorVersion < 17 || majorVersion > 21) {
+			String message = "OpenMRS Standalone requires Java 17 through 21 (Java 17 is recommended).\n"
 					+ "You are currently running Java " + javaVersion + ".\n\n"
-					+ (majorVersion > 23 ? "Java 24+ removes security features required by OpenMRS, causing startup failures.\n" : "")
+					+ (majorVersion > 21 ? "Java 24+ removes security features required by OpenMRS, causing startup failures.\n" : "")
 					+ "Please install a supported Java version and use it to run this application.";
 			try {
 				javax.swing.JOptionPane.showMessageDialog(null, message, "Unsupported Java Version", javax.swing.JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
## Issue work on 
https://openmrs.atlassian.net/browse/STAND-142
## Description 
This PR fixes two related startup crashes in the Standalone wrapper when run on modern OS environments with Java 24+:
1. **Fix Child Process Mismatch:** `Bootstrap.java` previously hardcoded the `"java"` command when spawning Tomcat, causing it to blindly default to the system `PATH` (e.g., Java 24) instead of the Java runtime used to launch the `.jar`. It now uses `System.getProperty("java.home")` to explicitly inherit the correct Java binary.
2. **Add Fast-Fail Validation:** Because Infinispan 13 crashes on Java 24+ due to the removal of `SecurityManager` (JEP 486), launching on an unsupported JDK would cause a cryptic `getSubject is not supported` console error. The wrapper now explicitly checks that the JVM is between Java 17 and 21. If out of range, it gracefully prevents startup and shows a helpful GUI error dialog to the user.
## Screenshots
**Before: (When launched on Java 24+):**
<img width="1644" height="967" alt="Screenshot 2026-04-30 at 3 26 14 PM" src="https://github.com/user-attachments/assets/872bd87e-3ec9-41c9-82c2-389acfc17701" />


**After (When launched on Java 24+):**
<img width="712" height="248" alt="Screenshot 2026-04-30 at 4 39 38 PM" src="https://github.com/user-attachments/assets/9309bacf-507c-4173-b1c0-cf337397dbca" />


**After (When launched on Java 17+ - Java 21):**
<img width="1644" height="971" alt="Screenshot 2026-04-30 at 1 18 24 PM" src="https://github.com/user-attachments/assets/c41e45bf-0772-48b3-8f88-30bcfab9535c" />

## Testing Instructions
1. Run `java -jar openmrs-standalone.jar` on a machine with Java 24+. Verify the new GUI error dialog pops up immediately.
2. Run on Java 17 or Java 21. Verify the standalone app boots successfully without crashing.