### PR TITLE
STAND-143: Add GitHub Actions 3.x Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: 3.x Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Pre-run OpenMRS SDK Plugin
+        run: mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:setup-sdk -B --settings .github/maven-settings.xml
+
+      - name: Run Maven Clean
+        run: mvn clean --settings .github/maven-settings.xml
+
+      - name: Run Maven Package
+        run: mvn package --settings .github/maven-settings.xml
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: target/referenceapplication-standalone-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: 3.x Release
 on:
   push:
     tags:
-      - 'v*'
+      - '3.x-v*'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: 3.x Release
 on:
   push:
     tags:
-      - '3.x-v*'
+      - 'refapp-v*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Issue Worked on 
https://openmrs.atlassian.net/browse/STAND-143
## Description
Adds a dedicated `release.yml` GitHub Actions workflow to the `openmrs-emr3` branch to enable automated building and publishing of the Reference Application 3.x standalone.

Previously, this branch lacked a release mechanism, preventing the community from accessing automated, downloadable zip artifacts for the 3.x standalone.

## Changes
- **New Workflow:** Created `.github/workflows/release.yml` (named "3.x Release").
- **Tag Pattern:** Configured to trigger on tags matching `refapp-v*` (e.g., `refapp-v3.7.0-SNAPSHOT`). This prevents interference with the `master` branch's `v*` tag pattern.
- **Build Configuration:** Uses Java 21 and the existing `.github/maven-settings.xml` to ensure consistency with the CI environment.
- **Release Assets:** Automatically builds and attaches `referenceapplication-standalone-*.zip` to the GitHub Release.

## How to Release 
To trigger a new release, push a tag using the new naming convention:
```bash
git tag refapp-v3.7.0-SNAPSHOT
git push upstream refapp-v3.7.0-SNAPSHOT
